### PR TITLE
publish tf to interactive marker position

### DIFF
--- a/src/interactive_marker_server.cpp
+++ b/src/interactive_marker_server.cpp
@@ -32,6 +32,7 @@
 #include "interactive_markers/interactive_marker_server.h"
 
 #include <visualization_msgs/InteractiveMarkerInit.h>
+#include <tf/transform_broadcaster.h>
 
 #include <boost/bind.hpp>
 #include <boost/make_shared.hpp>
@@ -440,6 +441,42 @@ void InteractiveMarkerServer::publish( visualization_msgs::InteractiveMarkerUpda
   update.server_id = server_id_;
   update.seq_num = seq_num_;
   update_pub_.publish( update );
+  //
+  // publish tf update_it->second.int_marker.pose -> feedback->marker_name;
+  for(M_MarkerContext::iterator it = marker_contexts_.begin(); it != marker_contexts_.end(); it++) {
+    ROS_DEBUG( "Markers '%s' publish tf from ~%s to %s",
+	       it->first.c_str(),
+	       it->second.int_marker.header.frame_id.c_str(),
+	       it->second.int_marker.name.c_str() );
+    static tf::TransformBroadcaster br;
+    tf::Transform transform;
+    geometry_msgs::Pose pose;
+    pose = it->second.int_marker.pose;
+
+    transform.setOrigin( tf::Vector3( pose.position.x,
+				      pose.position.y,
+				      pose.position.z ));
+    
+    if( (pose.orientation.x =! pose.orientation.x) ||
+	(pose.orientation.y =! pose.orientation.y) ||
+	(pose.orientation.z =! pose.orientation.z) ||
+	(pose.orientation.w =! pose.orientation.w) ){
+      transform.setRotation( tf::Quaternion( 0,
+					     0,
+					     0,
+					     1 ));
+    }else{
+      transform.setRotation( tf::Quaternion( pose.orientation.x,
+					     pose.orientation.y,
+					     pose.orientation.z,
+					     pose.orientation.w ));
+    }
+    
+    br.sendTransform( tf::StampedTransform( transform,
+					    ros::Time::now(),
+					    it->second.int_marker.header.frame_id,
+					    it->second.int_marker.name ));
+  }
 }
 
 

--- a/src/interactive_markers/interactive_marker_server.py
+++ b/src/interactive_markers/interactive_marker_server.py
@@ -31,6 +31,8 @@
 
 import roslib; roslib.load_manifest("interactive_markers")
 import rospy
+import tf
+import math
 
 from visualization_msgs.msg import *
 from std_msgs.msg import Header
@@ -351,6 +353,23 @@ class InteractiveMarkerServer:
         update.server_id = self.server_id
         update.seq_num = self.seq_num
         self.update_pub.publish( update)
+        for name, marker_context in self.marker_contexts.items():
+            pose = marker_context.int_marker.pose
+            br = tf.TransformBroadcaster()
+            if (pose.orientation.x == 0.0) and (pose.orientation.y == 0.0) and (pose.orientation.z == 0.0) and (pose.orientation.w == 0.0):
+                br.sendTransform((pose.position.x, pose.position.y, pose.position.z),
+                                 (0,0,0,1),
+                                 rospy.Time.now(),
+                                 marker_context.int_marker.name,
+                                 marker_context.int_marker.header.frame_id
+                                 )
+            else:
+                br.sendTransform((pose.position.x, pose.position.y, pose.position.z),
+                                 (pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w),
+                                 rospy.Time.now(),
+                                 marker_context.int_marker.name,
+                                 marker_context.int_marker.header.frame_id
+                                 )
         
     # publish the current complete state to the latched "init" topic
     def publishInit(self):


### PR DESCRIPTION
I want to set InteractiveMarker to another InteractiveMarker's frame_id, so that we can create cascaded InteractiveMarker.
Attached is patch to InteractiveMarkerServer publishes tf to InteractiveMarkers position.
