### PR TITLE
Fixed a SEGFAULT in setPose reported in #18

### DIFF
--- a/src/interactive_marker_server.cpp
+++ b/src/interactive_marker_server.cpp
@@ -225,10 +225,21 @@ bool InteractiveMarkerServer::setPose( const std::string &name, const geometry_m
     return false;
   }
 
+  // keep the old header
   if ( header.frame_id.empty() )
   {
-    // keep the old header
-    doSetPose( update_it, name, pose, marker_context_it->second.int_marker.header );
+    if ( marker_context_it != marker_contexts_.end() )
+    {
+      doSetPose( update_it, name, pose, marker_context_it->second.int_marker.header );
+    }
+    else if ( update_it != pending_updates_.end() )
+    {
+      doSetPose( update_it, name, pose, update_it->second.int_marker.header );
+    }
+    else
+    {
+      return false; // this should never happen
+    }
   }
   else
   {

--- a/src/interactive_marker_server.cpp
+++ b/src/interactive_marker_server.cpp
@@ -238,7 +238,8 @@ bool InteractiveMarkerServer::setPose( const std::string &name, const geometry_m
     }
     else
     {
-      return false; // this should never happen
+      BOOST_ASSERT_MSG(false, "Marker does not exist and there is no pending creation.");
+      return false;
     }
   }
   else

--- a/src/test/server_test.cpp
+++ b/src/test/server_test.cpp
@@ -85,7 +85,7 @@ TEST(InteractiveMarkerServer, addRemove)
   ASSERT_FALSE( server.get("marker1", int_marker) );
 
   //insert, setPose, apply, clear, apply
-  ASSERT_TRUE( server.insert(int_marker) );
+  server.insert(int_marker);
   ASSERT_TRUE( server.setPose("marker1", pose) );
 
   server.applyChanges();

--- a/src/test/server_test.cpp
+++ b/src/test/server_test.cpp
@@ -43,6 +43,10 @@ TEST(InteractiveMarkerServer, addRemove)
   visualization_msgs::InteractiveMarker int_marker;
   int_marker.name = "marker1";
 
+  // create a valid pose
+  geometry_msgs::Pose pose;
+  pose.orientation.w = 1.0;
+
   //insert, apply, erase, apply
   server.insert(int_marker);
   ASSERT_TRUE( server.get("marker1", int_marker) );
@@ -79,6 +83,16 @@ TEST(InteractiveMarkerServer, addRemove)
 
   server.applyChanges();
   ASSERT_FALSE( server.get("marker1", int_marker) );
+
+  //insert, setPose, apply, clear, apply
+  ASSERT_TRUE( server.insert(int_marker) );
+  ASSERT_TRUE( server.setPose("marker1", pose) );
+
+  server.applyChanges();
+  server.clear();
+  ASSERT_FALSE( server.get("marker1", int_marker) );
+
+  server.applyChanges();
 
   //avoid subscriber destruction warning
   usleep(1000);


### PR DESCRIPTION
Previously, calling setPose() on an interactive marker causes a SEGFAULT if applyChanges() was not called on the server at least once since the marker was created. I traced the actual SEGFAULT to the doSetPose function. The value of header passed from setPose() is invalid because, in this case, marker_context_it = marker_contexts_.end().

I added a check for this case and, if there is no marker is present, instead use the header from the pending update. I'm not 100% sure that this is the correct solution, so it would be good to get input from someone who is more familiar with the code base.
