### PR TITLE
[Indigo] add explicit keyword argument queue_size for publisher

### DIFF
--- a/src/interactive_markers/interactive_marker_server.py
+++ b/src/interactive_markers/interactive_marker_server.py
@@ -94,8 +94,8 @@ class InteractiveMarkerServer:
         # string : UpdateContext
         self.pending_updates = dict()
 
-        self.init_pub = rospy.Publisher(topic_ns+"/update_full", InteractiveMarkerInit, latch=True)
-        self.update_pub = rospy.Publisher(topic_ns+"/update", InteractiveMarkerUpdate)
+        self.init_pub = rospy.Publisher(topic_ns+"/update_full", InteractiveMarkerInit, latch=True, queue_size=1)
+        self.update_pub = rospy.Publisher(topic_ns+"/update", InteractiveMarkerUpdate, queue_size=30)
 
         rospy.Subscriber(topic_ns+"/feedback", InteractiveMarkerFeedback, self.processFeedback, queue_size=q_size)
         rospy.Timer(rospy.Duration(0.5), self.keepAlive)


### PR DESCRIPTION
I see the following SyntaxWarning when using the InteractiveMarkerServer with Python:

```
/opt/ros/indigo/lib/python2.7/dist-packages/interactive_markers/interactive_marker_server.py:97: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  self.init_pub = rospy.Publisher(topic_ns+"/update_full", InteractiveMarkerInit, latch=True)
/opt/ros/indigo/lib/python2.7/dist-packages/interactive_markers/interactive_marker_server.py:98: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  self.update_pub = rospy.Publisher(topic_ns+"/update", InteractiveMarkerUpdate)
```

I'm not sure whether this should be fixed and if yes whether the `queue_sizes` I chose are appropriate...so this is open for discussion!
(I chose `queue_size=30` for update as the markers is re-initialized when I set it to only `queue_size=1`. 30 is the default frame_rate in RVIZ.)
