### PR TITLE
state_machine.h: fix initialization of state_, chg_time_

### DIFF
--- a/include/interactive_markers/detail/state_machine.h
+++ b/include/interactive_markers/detail/state_machine.h
@@ -60,9 +60,10 @@ private:
 
 template<class StateT>
 StateMachine<StateT>::StateMachine( std::string name, StateT init_state )
-: name_(name)
+: state_(init_state)
+, chg_time_(ros::Time::now())
+, name_(name)
 {
-  operator=(init_state);
 };
 
 template<class StateT>


### PR DESCRIPTION
The old code called operator=() to initialize, which checked
state_ to determine whether a change was really needed. Of course,
at that point in time state_ was still uninitialized (=> undefined behavior).
So do the initialization explicitly.

Found using valgrind.
