### PR TITLE
InteractiveMarkerClient: harden callback code against shutdown()

### DIFF
--- a/src/interactive_marker_client.cpp
+++ b/src/interactive_marker_client.cpp
@@ -232,11 +232,19 @@ void InteractiveMarkerClient::update()
     M_SingleClient::iterator it;
     for ( it = publisher_contexts_.begin(); it!=publisher_contexts_.end(); ++it )
     {
-      it->second->update();
-      if ( !it->second->isInitialized() )
+      // Explicitly reference the pointer to the client here, because the client
+      // might call user code, which might call shutdown(), which will delete
+      // the publisher_contexts_ map...
+
+      SingleClientPtr single_client = it->second;
+      single_client->update();
+      if ( !single_client->isInitialized() )
       {
         initialized = false;
       }
+
+      if ( publisher_contexts_.empty() )
+        break; // Yep, someone called shutdown()...
     }
     if ( state_ == INIT && initialized )
     {


### PR DESCRIPTION
The user-supplied callback called by `SingleClient` might actually call `InteractiveMarkerClient::shutdown()` (rviz does this). In that case, we delete the `SingleClient` which is doing the current call, which leads to memory corruption when execution returns to it.

Changes:
1. Explicitly keep a reference to the current SingleClient being update()d
2. Detect that the client map was cleared by the callback and stop iterating

Found using valgrind.
