### PR TITLE
processFeedback keyError handling

### DIFF
--- a/src/interactive_markers/menu_handler.py
+++ b/src/interactive_markers/menu_handler.py
@@ -138,9 +138,9 @@ class MenuHandler:
     def processFeedback(self, feedback):
         try:
             context = self.entry_contexts_[feedback.menu_entry_id]
-            context.feedback_cb(feedback)
         except KeyError:
-            pass
+            return
+        context.feedback_cb(feedback)
 
     # Create and push MenuEntry objects from handles_in onto
     # entries_out. Calls itself recursively to add the entire menu tree.


### PR DESCRIPTION
the processFeedback function in menu handler should not catch the keyErrors of the feedback_cb but just the key Error of the dictionary access.
