### PR TITLE
Add empty() and size() members to InteractiveMarkerServer

### DIFF
--- a/include/interactive_markers/interactive_marker_server.h
+++ b/include/interactive_markers/interactive_marker_server.h
@@ -109,6 +109,16 @@ public:
   /// Clear all markers.
   /// Note: This change will not take effect until you call applyChanges().
   void clear();
+  
+  /// Return whether the server contains any markers.
+  /// Note: Does not include markers inserted since the last applyChanges().
+  /// @return true if the server contains no markers
+  bool empty() const;
+  
+  /// Return the number of markers contained in the server
+  /// Note: Does not include markers inserted since the last applyChanges().
+  /// @return The number of markers contained in the server
+  std::size_t size() const;
 
   /// Add or replace a callback function for the specified marker.
   /// Note: This change will not take effect until you call applyChanges().

--- a/src/interactive_marker_server.cpp
+++ b/src/interactive_marker_server.cpp
@@ -211,6 +211,18 @@ void InteractiveMarkerServer::clear()
 }
 
 
+bool InteractiveMarkerServer::empty() const
+{
+  return marker_contexts_.empty();
+}
+
+
+std::size_t InteractiveMarkerServer::size() const
+{
+  return marker_contexts_.size();
+}
+
+
 bool InteractiveMarkerServer::setPose( const std::string &name, const geometry_msgs::Pose &pose, const std_msgs::Header &header )
 {
   boost::recursive_mutex::scoped_lock lock( mutex_ );


### PR DESCRIPTION
I added two member methods, empty() and size(), to InteractiveMarkerServer to help me with a certain application. They basically expose the same members of the private marker_contexts_ member.
