### PR TITLE
Make the Timer daemon survive /clock jumping back in a playback loop

### DIFF
--- a/src/interactive_markers/interactive_marker_server.py
+++ b/src/interactive_markers/interactive_marker_server.py
@@ -98,7 +98,7 @@ class InteractiveMarkerServer:
         self.update_pub = rospy.Publisher(topic_ns+"/update", InteractiveMarkerUpdate, queue_size=100)
 
         rospy.Subscriber(topic_ns+"/feedback", InteractiveMarkerFeedback, self.processFeedback, queue_size=q_size)
-        rospy.Timer(rospy.Duration(0.5), self.keepAlive)
+        rospy.Timer(rospy.Duration(0.5), self.keepAlive, reset=True)
 
         self.publishInit()
 


### PR DESCRIPTION
This PR makes the Timer daemon survive /clock jumping back in a playback loop, as described [here](https://answers.ros.org/question/233187/interactive-marker-with-rosbag-ros-time-moved-backwards/).

Previously, without this setting, the timer daemon will raise `ROSTimeMovedBackwardsException` (Time moved backwards) and exit. There seems to be no reason to not just reset the timer and continue operation.