### PR TITLE
[windows] add visibility control and install binaries to portable locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,15 @@ src/message_context.cpp
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE "INTERACTIVE_MARKERS_BUILDING_LIBRARY")
+
 install(TARGETS ${PROJECT_NAME}
-  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
 install(DIRECTORY include/interactive_markers/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h")

--- a/include/interactive_markers/interactive_marker_client.h
+++ b/include/interactive_markers/interactive_marker_client.h
@@ -46,6 +46,7 @@
 
 #include <visualization_msgs/InteractiveMarkerInit.h>
 #include <visualization_msgs/InteractiveMarkerUpdate.h>
+#include <interactive_markers/visibility_control.hpp>
 
 #include "detail/state_machine.h"
 
@@ -85,37 +86,48 @@ public:
   /// @param tf           The tf transformer to use.
   /// @param target_frame tf frame to transform timestamped messages into.
   /// @param topic_ns     The topic namespace (will subscribe to topic_ns/update, topic_ns/init)
+  INTERACTIVE_MARKERS_PUBLIC
   InteractiveMarkerClient( tf::Transformer& tf,
       const std::string& target_frame = "",
       const std::string &topic_ns = "" );
 
   /// Will cause a 'reset' call for all server ids
+  INTERACTIVE_MARKERS_PUBLIC
   ~InteractiveMarkerClient();
 
   /// Subscribe to the topics topic_ns/update and topic_ns/init
+  INTERACTIVE_MARKERS_PUBLIC
   void subscribe( std::string topic_ns );
 
   /// Unsubscribe, clear queues & call reset callbacks
+  INTERACTIVE_MARKERS_PUBLIC
   void shutdown();
 
   /// Update tf info, call callbacks
+  INTERACTIVE_MARKERS_PUBLIC
   void update();
 
   /// Change the target frame and reset the connection
+  INTERACTIVE_MARKERS_PUBLIC
   void setTargetFrame( std::string target_frame );
 
   /// Set callback for init messages
+  INTERACTIVE_MARKERS_PUBLIC
   void setInitCb( const InitCallback& cb );
 
   /// Set callback for update messages
+  INTERACTIVE_MARKERS_PUBLIC
   void setUpdateCb( const UpdateCallback& cb );
 
   /// Set callback for resetting one server connection
+  INTERACTIVE_MARKERS_PUBLIC
   void setResetCb( const ResetCallback& cb );
 
   /// Set callback for status updates
+  INTERACTIVE_MARKERS_PUBLIC
   void setStatusCb( const StatusCallback& cb );
 
+  INTERACTIVE_MARKERS_PUBLIC
   void setEnableAutocompleteTransparency( bool enable ) { enable_autocomplete_transparency_ = enable;}
 
 private:

--- a/include/interactive_markers/interactive_marker_server.h
+++ b/include/interactive_markers/interactive_marker_server.h
@@ -34,6 +34,7 @@
 
 #include <visualization_msgs/InteractiveMarkerUpdate.h>
 #include <visualization_msgs/InteractiveMarkerFeedback.h>
+#include <interactive_markers/visibility_control.hpp>
 
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread/thread.hpp>
@@ -69,15 +70,18 @@ public:
   ///                      Otherwise, leave this empty.
   /// @param spin_thread   If set to true, will spin up a thread for message handling.
   ///                      All callbacks will be called from that thread.
+  INTERACTIVE_MARKERS_PUBLIC
   InteractiveMarkerServer( const std::string &topic_ns, const std::string &server_id="", bool spin_thread = false );
 
   /// Destruction of the interface will lead to all managed markers being cleared.
+  INTERACTIVE_MARKERS_PUBLIC
   ~InteractiveMarkerServer();
 
   /// Add or replace a marker without changing its callback functions.
   /// Note: Changes to the marker will not take effect until you call applyChanges().
   /// The callback changes immediately.
   /// @param int_marker     The marker to be added or replaced
+  INTERACTIVE_MARKERS_PUBLIC
   void insert( const visualization_msgs::InteractiveMarker &int_marker );
 
   /// Add or replace a marker and its callback functions
@@ -86,6 +90,7 @@ public:
   /// @param int_marker     The marker to be added or replaced
   /// @param feedback_cb    Function to call on the arrival of a feedback message.
   /// @param feedback_type  Type of feedback for which to call the feedback.
+  INTERACTIVE_MARKERS_PUBLIC
   void insert( const visualization_msgs::InteractiveMarker &int_marker,
                FeedbackCallback feedback_cb,
                uint8_t feedback_type=DEFAULT_FEEDBACK_CB );
@@ -96,6 +101,7 @@ public:
   /// @param name    Name of the interactive marker
   /// @param pose    The new pose
   /// @param header  Header replacement. Leave this empty to use the previous one.
+  INTERACTIVE_MARKERS_PUBLIC
   bool setPose( const std::string &name,
       const geometry_msgs::Pose &pose,
       const std_msgs::Header &header=std_msgs::Header() );
@@ -104,20 +110,24 @@ public:
   /// Note: This change will not take effect until you call applyChanges().
   /// @return true if a marker with that name exists
   /// @param name  Name of the interactive marker
+  INTERACTIVE_MARKERS_PUBLIC
   bool erase( const std::string &name );
 
   /// Clear all markers.
   /// Note: This change will not take effect until you call applyChanges().
+  INTERACTIVE_MARKERS_PUBLIC
   void clear();
   
   /// Return whether the server contains any markers.
   /// Note: Does not include markers inserted since the last applyChanges().
   /// @return true if the server contains no markers
+  INTERACTIVE_MARKERS_PUBLIC
   bool empty() const;
   
   /// Return the number of markers contained in the server
   /// Note: Does not include markers inserted since the last applyChanges().
   /// @return The number of markers contained in the server
+  INTERACTIVE_MARKERS_PUBLIC
   std::size_t size() const;
 
   /// Add or replace a callback function for the specified marker.
@@ -130,17 +140,20 @@ public:
   /// @param feedback_cb    Function to call on the arrival of a feedback message.
   /// @param feedback_type  Type of feedback for which to call the feedback.
   ///                       Leave this empty to make this the default callback.
+  INTERACTIVE_MARKERS_PUBLIC
   bool setCallback( const std::string &name, FeedbackCallback feedback_cb,
       uint8_t feedback_type=DEFAULT_FEEDBACK_CB );
 
   /// Apply changes made since the last call to this method &
   /// broadcast an update to all clients.
+  INTERACTIVE_MARKERS_PUBLIC
   void applyChanges();
 
   /// Get marker by name
   /// @param name             Name of the interactive marker
   /// @param[out] int_marker  Output message
   /// @return true if a marker with that name exists
+  INTERACTIVE_MARKERS_PUBLIC
   bool get( std::string name, visualization_msgs::InteractiveMarker &int_marker ) const;
 
 private:

--- a/include/interactive_markers/menu_handler.h
+++ b/include/interactive_markers/menu_handler.h
@@ -34,6 +34,7 @@
 
 #include <visualization_msgs/MenuEntry.h>
 #include <interactive_markers/interactive_marker_server.h>
+#include <interactive_markers/visibility_control.hpp>
 
 #include <boost/function.hpp>
 #include <boost/unordered_map.hpp>

--- a/include/interactive_markers/tools.h
+++ b/include/interactive_markers/tools.h
@@ -31,6 +31,7 @@
 #define RVIZ_INTERACTIVE_MARKER_TOOLS_H
 
 #include <visualization_msgs/InteractiveMarker.h>
+#include <interactive_markers/visibility_control.hpp>
 
 namespace interactive_markers
 {
@@ -39,11 +40,13 @@ namespace interactive_markers
  *
  * This also calls uniqueifyControlNames().
  * @param msg      interactive marker to be completed */
+INTERACTIVE_MARKERS_PUBLIC
 void autoComplete( visualization_msgs::InteractiveMarker &msg, bool enable_autocomplete_transparency = true );
 
 /// @brief fill in default values & insert default controls when none are specified
 /// @param msg      interactive marker which contains the control
 /// @param control  the control to be completed
+INTERACTIVE_MARKERS_PUBLIC
 void autoComplete( const visualization_msgs::InteractiveMarker &msg,
     visualization_msgs::InteractiveMarkerControl &control, bool enable_autocomplete_transparency = true );
 
@@ -51,11 +54,13 @@ void autoComplete( const visualization_msgs::InteractiveMarker &msg,
  *
  * Appends _u0 _u1 etc to repeated names (not including the first of each).
  * This is called by autoComplete( visualization_msgs::InteractiveMarker &msg ). */
+INTERACTIVE_MARKERS_PUBLIC
 void uniqueifyControlNames( visualization_msgs::InteractiveMarker& msg );
 
 /// make a quaternion with a fixed local x axis.
 /// The rotation around that axis will be chosen automatically.
 /// @param x,y,z    the designated x axis
+INTERACTIVE_MARKERS_PUBLIC
 geometry_msgs::Quaternion makeQuaternion( float x, float y, float z );
 
 
@@ -65,25 +70,30 @@ geometry_msgs::Quaternion makeQuaternion( float x, float y, float z );
 /// @param msg      the interactive marker that this will go into
 /// @param control  the control where to insert the arrow marker
 /// @param pos      how far from the center should the arrow be, and on which side
+INTERACTIVE_MARKERS_PUBLIC
 void makeArrow( const visualization_msgs::InteractiveMarker &msg,
     visualization_msgs::InteractiveMarkerControl &control, float pos );
 
 /// @brief make a default-style disc marker (e.g for rotating) based on the properties of the given interactive marker
 /// @param msg      the interactive marker that this will go into
 /// @param width    width of the disc, relative to its inner radius
+INTERACTIVE_MARKERS_PUBLIC
 void makeDisc( const visualization_msgs::InteractiveMarker &msg,
     visualization_msgs::InteractiveMarkerControl &control, float width = 0.3 );
 
 /// @brief make a box which shows the given text and is view facing
 /// @param msg      the interactive marker that this will go into
 /// @param text     the text to display
+INTERACTIVE_MARKERS_PUBLIC
 void makeViewFacingButton( const visualization_msgs::InteractiveMarker &msg,
     visualization_msgs::InteractiveMarkerControl &control, std::string text );
 
 /// assign an RGB value to the given marker based on the given orientation
+INTERACTIVE_MARKERS_PUBLIC
 void assignDefaultColor(visualization_msgs::Marker &marker, const geometry_msgs::Quaternion &quat );
 
 /// create a control which shows the description of the interactive marker
+INTERACTIVE_MARKERS_PUBLIC
 visualization_msgs::InteractiveMarkerControl makeTitle( const visualization_msgs::InteractiveMarker &msg );
 
 }

--- a/include/interactive_markers/visibility_control.hpp
+++ b/include/interactive_markers/visibility_control.hpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of Open Source Robotics Foundation, Inc. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INTERACTIVE_MARKERS__VISIBILITY_CONTROL_HPP_
+#define INTERACTIVE_MARKERS__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define INTERACTIVE_MARKERS_EXPORT __attribute__ ((dllexport))
+    #define INTERACTIVE_MARKERS_IMPORT __attribute__ ((dllimport))
+  #else
+    #define INTERACTIVE_MARKERS_EXPORT __declspec(dllexport)
+    #define INTERACTIVE_MARKERS_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef INTERACTIVE_MARKERS_BUILDING_LIBRARY
+    #define INTERACTIVE_MARKERS_PUBLIC INTERACTIVE_MARKERS_EXPORT
+  #else
+    #define INTERACTIVE_MARKERS_PUBLIC INTERACTIVE_MARKERS_IMPORT
+  #endif
+  #define INTERACTIVE_MARKERS_PUBLIC_TYPE INTERACTIVE_MARKERS_PUBLIC
+  #define INTERACTIVE_MARKERS_LOCAL
+#else
+  #define INTERACTIVE_MARKERS_EXPORT __attribute__ ((visibility("default")))
+  #define INTERACTIVE_MARKERS_IMPORT
+  #if __GNUC__ >= 4
+    #define INTERACTIVE_MARKERS_PUBLIC __attribute__ ((visibility("default")))
+    #define INTERACTIVE_MARKERS_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define INTERACTIVE_MARKERS_PUBLIC
+    #define INTERACTIVE_MARKERS_LOCAL
+  #endif
+  #define INTERACTIVE_MARKERS_PUBLIC_TYPE
+#endif
+
+#endif  // INTERACTIVE_MARKERS__VISIBILITY_CONTROL_HPP_


### PR DESCRIPTION
cherry-pick Windows specific fixes from ROS2:
* Visibility control for shared library:
  * https://github.com/ros-visualization/interactive_markers/pull/44
  * https://github.com/ros-visualization/interactive_markers/pull/51
* Place the shared library to a portable location:
  * https://github.com/ros-visualization/interactive_markers/pull/44 (Adapted to the [catkin](https://docs.ros.org/api/catkin/html/howto/format1/building_libraries.html#installing) convention.)