### PR TITLE
[windows] conditionally use C++11 portable sleep.

### DIFF
--- a/src/test/bursty_tf.cpp
+++ b/src/test/bursty_tf.cpp
@@ -37,6 +37,20 @@
 
 #include <math.h>
 
+#if __cplusplus >= 199711L
+#include <chrono>
+#include <thread>
+#endif
+
+static void portable_usleep(unsigned int usecs)
+{
+#if __cplusplus >= 199711L
+  return std::this_thread::sleep_for(std::chrono::microseconds(usecs));
+#else
+  return usleep(usecs);
+#endif
+}
+
 boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server;
 
 using namespace visualization_msgs;
@@ -152,7 +166,7 @@ void frameCallback(const ros::TimerEvent&)
     if (!sending) ROS_INFO("on");
     sending = true;
     br.sendTransform(tf::StampedTransform(t, time, "base_link", "bursty_frame"));
-    usleep(10000);
+    portable_usleep(10000);
   }
   else
   {

--- a/src/test/bursty_tf.cpp
+++ b/src/test/bursty_tf.cpp
@@ -155,7 +155,7 @@ void frameCallback(const ros::TimerEvent&)
     if (!sending) ROS_INFO("on");
     sending = true;
     br.sendTransform(tf::StampedTransform(t, time, "base_link", "bursty_frame"));
-    std::this_thread::sleep_for(std::chrono::microseconds(10000))
+    std::this_thread::sleep_for(std::chrono::microseconds(10000));
   }
   else
   {

--- a/src/test/bursty_tf.cpp
+++ b/src/test/bursty_tf.cpp
@@ -37,19 +37,8 @@
 
 #include <math.h>
 
-#if __cplusplus >= 199711L
 #include <chrono>
 #include <thread>
-#endif
-
-static void portable_usleep(unsigned int usecs)
-{
-#if __cplusplus >= 199711L
-  return std::this_thread::sleep_for(std::chrono::microseconds(usecs));
-#else
-  return usleep(usecs);
-#endif
-}
 
 boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server;
 
@@ -166,7 +155,7 @@ void frameCallback(const ros::TimerEvent&)
     if (!sending) ROS_INFO("on");
     sending = true;
     br.sendTransform(tf::StampedTransform(t, time, "base_link", "bursty_frame"));
-    portable_usleep(10000);
+    std::this_thread::sleep_for(std::chrono::microseconds(10000))
   }
   else
   {

--- a/src/test/server_client_test.cpp
+++ b/src/test/server_client_test.cpp
@@ -38,19 +38,8 @@
 #include <interactive_markers/interactive_marker_server.h>
 #include <interactive_markers/interactive_marker_client.h>
 
-#if __cplusplus >= 199711L
 #include <chrono>
 #include <thread>
-#endif
-
-static void portable_usleep(unsigned int usecs)
-{
-#if __cplusplus >= 199711L
-  return std::this_thread::sleep_for(std::chrono::microseconds(usecs));
-#else
-  return usleep(usecs);
-#endif
-}
 
 #define DBG_MSG( ... ) printf( __VA_ARGS__ ); printf("\n");
 #define DBG_MSG_STREAM( ... )  std::cout << __VA_ARGS__ << std::endl;
@@ -117,7 +106,7 @@ void waitMsg()
   for(int i=0;i<10;i++)
   {
     ros::spinOnce();
-    portable_usleep(1000);
+    std::this_thread::sleep_for(std::chrono::microseconds(1000))
   }
 }
 
@@ -198,7 +187,7 @@ TEST(InteractiveMarkerServerAndClient, connect_tf_error)
   // Make marker tf info valid again -> connection should be successfully initialized again
   DBG_MSG("----------------------------------------");
 
-  portable_usleep(2000000);
+  std::this_thread::sleep_for(std::chrono::microseconds(2000000))
   waitMsg();
   client.update();
 

--- a/src/test/server_client_test.cpp
+++ b/src/test/server_client_test.cpp
@@ -106,7 +106,7 @@ void waitMsg()
   for(int i=0;i<10;i++)
   {
     ros::spinOnce();
-    std::this_thread::sleep_for(std::chrono::microseconds(1000))
+    std::this_thread::sleep_for(std::chrono::microseconds(1000));
   }
 }
 
@@ -187,7 +187,7 @@ TEST(InteractiveMarkerServerAndClient, connect_tf_error)
   // Make marker tf info valid again -> connection should be successfully initialized again
   DBG_MSG("----------------------------------------");
 
-  std::this_thread::sleep_for(std::chrono::microseconds(2000000))
+  std::this_thread::sleep_for(std::chrono::microseconds(2000000));
   waitMsg();
   client.update();
 

--- a/src/test/server_client_test.cpp
+++ b/src/test/server_client_test.cpp
@@ -38,6 +38,20 @@
 #include <interactive_markers/interactive_marker_server.h>
 #include <interactive_markers/interactive_marker_client.h>
 
+#if __cplusplus >= 199711L
+#include <chrono>
+#include <thread>
+#endif
+
+static void portable_usleep(unsigned int usecs)
+{
+#if __cplusplus >= 199711L
+  return std::this_thread::sleep_for(std::chrono::microseconds(usecs));
+#else
+  return usleep(usecs);
+#endif
+}
+
 #define DBG_MSG( ... ) printf( __VA_ARGS__ ); printf("\n");
 #define DBG_MSG_STREAM( ... )  std::cout << __VA_ARGS__ << std::endl;
 
@@ -103,7 +117,7 @@ void waitMsg()
   for(int i=0;i<10;i++)
   {
     ros::spinOnce();
-    usleep(1000);
+    portable_usleep(1000);
   }
 }
 
@@ -184,7 +198,7 @@ TEST(InteractiveMarkerServerAndClient, connect_tf_error)
   // Make marker tf info valid again -> connection should be successfully initialized again
   DBG_MSG("----------------------------------------");
 
-  usleep(2000000);
+  portable_usleep(2000000);
   waitMsg();
   client.update();
 

--- a/src/test/server_test.cpp
+++ b/src/test/server_test.cpp
@@ -34,19 +34,8 @@
 
 #include <interactive_markers/interactive_marker_server.h>
 
-#if __cplusplus >= 199711L
 #include <chrono>
 #include <thread>
-#endif
-
-static void portable_usleep(unsigned int usecs)
-{
-#if __cplusplus >= 199711L
-  return std::this_thread::sleep_for(std::chrono::microseconds(usecs));
-#else
-  return usleep(usecs);
-#endif
-}
 
 TEST(InteractiveMarkerServer, addRemove)
 {
@@ -112,7 +101,7 @@ TEST(InteractiveMarkerServer, addRemove)
   ASSERT_FALSE( server.erase("marker1") );
 
   //avoid subscriber destruction warning
-  portable_usleep(1000);
+  std::this_thread::sleep_for(std::chrono::microseconds(1000));
 }
 
 

--- a/src/test/server_test.cpp
+++ b/src/test/server_test.cpp
@@ -34,6 +34,20 @@
 
 #include <interactive_markers/interactive_marker_server.h>
 
+#if __cplusplus >= 199711L
+#include <chrono>
+#include <thread>
+#endif
+
+static void portable_usleep(unsigned int usecs)
+{
+#if __cplusplus >= 199711L
+  return std::this_thread::sleep_for(std::chrono::microseconds(usecs));
+#else
+  return usleep(usecs);
+#endif
+}
+
 TEST(InteractiveMarkerServer, addRemove)
 {
   // create an interactive marker server on the topic namespace simple_marker
@@ -98,7 +112,7 @@ TEST(InteractiveMarkerServer, addRemove)
   ASSERT_FALSE( server.erase("marker1") );
 
   //avoid subscriber destruction warning
-  usleep(1000);
+  portable_usleep(1000);
 }
 
 


### PR DESCRIPTION
On ROS 2 branches, the test uses `C++11`'s `<chrono>` and `<thread>` to implement the portable sleep. However, `Indigo-devel` targets `C++03` , in order not to break this assumption, I decided to conditionally use the `C++11` modern sleep only for the `C++11`-supported environment.