### PR TITLE
Migration to tf2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,14 @@ find_package(catkin REQUIRED
   rospy
   rostest
   std_msgs
-  tf
+  tf2_ros
+  tf2_geometry_msgs
   visualization_msgs
 )
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES interactive_markers
-  CATKIN_DEPENDS roscpp rosconsole rospy tf std_msgs visualization_msgs
+  CATKIN_DEPENDS roscpp rosconsole rospy tf2_ros std_msgs visualization_msgs
 )
 catkin_python_setup()
 

--- a/include/interactive_markers/detail/message_context.h
+++ b/include/interactive_markers/detail/message_context.h
@@ -37,7 +37,7 @@
 #ifndef MESSAGE_CONTEXT_H_
 #define MESSAGE_CONTEXT_H_
 
-#include <tf/tf.h>
+#include <tf2_ros/buffer.h>
 
 #include <visualization_msgs/InteractiveMarkerInit.h>
 #include <visualization_msgs/InteractiveMarkerUpdate.h>
@@ -49,7 +49,7 @@ template<class MsgT>
 class MessageContext
 {
 public:
-  MessageContext( tf::Transformer& tf,
+  MessageContext( tf2_ros::Buffer& tf,
       const std::string& target_frame,
       const typename MsgT::ConstPtr& msg,
       bool enable_autocomplete_transparency = true);
@@ -76,15 +76,15 @@ private:
   // array indices of marker/pose updates with missing tf info
   std::list<size_t> open_marker_idx_;
   std::list<size_t> open_pose_idx_;
-  tf::Transformer& tf_;
+  tf2_ros::Buffer& tf_;
   std::string target_frame_;
   bool enable_autocomplete_transparency_;
 };
 
-class InitFailException: public tf::TransformException
+class InitFailException: public tf2::TransformException
 {
 public:
-  InitFailException(const std::string errorDescription) : tf::TransformException(errorDescription) { ; }
+  InitFailException(const std::string errorDescription) : tf2::TransformException(errorDescription) { ; }
 };
 
 

--- a/include/interactive_markers/detail/single_client.h
+++ b/include/interactive_markers/detail/single_client.h
@@ -47,7 +47,7 @@
 #include <boost/function.hpp>
 #include <boost/unordered_map.hpp>
 
-#include <tf/tf.h>
+#include <tf2_ros/buffer.h>
 
 #include <deque>
 
@@ -65,7 +65,7 @@ public:
 
   SingleClient(
       const std::string& server_id,
-      tf::Transformer& tf,
+      tf2_ros::Buffer& tf,
       const std::string& target_frame,
       const InteractiveMarkerClient::CbCollection& callbacks );
 
@@ -131,7 +131,7 @@ private:
   // queue for init messages
   M_InitMessageContext init_queue_;
 
-  tf::Transformer& tf_;
+  tf2_ros::Buffer& tf_;
   std::string target_frame_;
 
   const InteractiveMarkerClient::CbCollection& callbacks_;

--- a/include/interactive_markers/interactive_marker_client.h
+++ b/include/interactive_markers/interactive_marker_client.h
@@ -42,7 +42,7 @@
 #include <ros/subscriber.h>
 #include <ros/node_handle.h>
 
-#include <tf/tf.h>
+#include <tf2_ros/buffer.h>
 
 #include <visualization_msgs/InteractiveMarkerInit.h>
 #include <visualization_msgs/InteractiveMarkerUpdate.h>
@@ -87,7 +87,7 @@ public:
   /// @param target_frame tf frame to transform timestamped messages into.
   /// @param topic_ns     The topic namespace (will subscribe to topic_ns/update, topic_ns/init)
   INTERACTIVE_MARKERS_PUBLIC
-  InteractiveMarkerClient( tf::Transformer& tf,
+  InteractiveMarkerClient(tf2_ros::Buffer &tf,
       const std::string& target_frame = "",
       const std::string &topic_ns = "" );
 
@@ -165,7 +165,7 @@ private:
   M_SingleClient publisher_contexts_;
   boost::mutex publisher_contexts_mutex_;
 
-  tf::Transformer& tf_;
+  tf2_ros::Buffer& tf_;
   std::string target_frame_;
 
 public:

--- a/include/interactive_markers/interactive_marker_client.h
+++ b/include/interactive_markers/interactive_marker_client.h
@@ -214,7 +214,7 @@ private:
   StatusCallback status_cb_;
 
   // this allows us to detect if a server died (in most cases)
-  int last_num_publishers_;
+  uint32_t last_num_publishers_;
 
   // if false, auto-completed markers will have alpha = 1.0
   bool enable_autocomplete_transparency_;

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <depend>rospy</depend>
   <depend>rostest</depend>
   <depend>std_msgs</depend>
-  <depend>tf</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>
 </package>

--- a/src/interactive_marker_client.cpp
+++ b/src/interactive_marker_client.cpp
@@ -43,7 +43,7 @@ namespace interactive_markers
 {
 
 InteractiveMarkerClient::InteractiveMarkerClient(
-    tf::Transformer& tf,
+    tf2_ros::Buffer& tf,
     const std::string& target_frame,
     const std::string &topic_ns )
 : state_("InteractiveMarkerClient",IDLE)

--- a/src/single_client.cpp
+++ b/src/single_client.cpp
@@ -42,7 +42,7 @@ namespace interactive_markers
 
 SingleClient::SingleClient(
     const std::string& server_id,
-    tf::Transformer& tf,
+    tf2_ros::Buffer &tf,
     const std::string& target_frame,
     const InteractiveMarkerClient::CbCollection& callbacks
 )

--- a/src/test/bursty_tf.cpp
+++ b/src/test/bursty_tf.cpp
@@ -30,8 +30,8 @@
 
 #include <ros/ros.h>
 
-#include <tf/transform_broadcaster.h>
-#include <tf/tf.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <interactive_markers/interactive_marker_server.h>
 
@@ -131,7 +131,7 @@ void make6DofMarker( bool fixed )
 
 void frameCallback(const ros::TimerEvent&)
 {
-  static tf::TransformBroadcaster br;
+  static tf2_ros::TransformBroadcaster br;
   static bool sending = true;
 
   geometry_msgs::Pose pose;
@@ -149,12 +149,15 @@ void frameCallback(const ros::TimerEvent&)
 
   if ( seconds % 2 < 1 )
   {
-    tf::Transform t;
-    t.setOrigin(tf::Vector3(0.0, 0.0, 1.0));
-    t.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
+    geometry_msgs::TransformStamped stf;
+    stf.header.frame_id = "base_link";
+    stf.header.stamp = time;
+    stf.child_frame_id = "bursty_frame";
+    stf.transform.translation = toMsg(tf2::Vector3(0.0, 0.0, 1.0));
+    stf.transform.rotation = toMsg(tf2::Quaternion(0.0, 0.0, 0.0, 1.0));
     if (!sending) ROS_INFO("on");
     sending = true;
-    br.sendTransform(tf::StampedTransform(t, time, "base_link", "bursty_frame"));
+    br.sendTransform(stf);
     std::this_thread::sleep_for(std::chrono::microseconds(10000));
   }
   else

--- a/src/test/client_test.cpp
+++ b/src/test/client_test.cpp
@@ -33,8 +33,6 @@
 
 #include <gtest/gtest.h>
 
-#include <tf/transform_listener.h>
-
 #include <interactive_markers/interactive_marker_server.h>
 #include <interactive_markers/interactive_marker_client.h>
 
@@ -120,9 +118,7 @@ class SequenceTest
 public:
   void test( std::vector<Msg> messages )
   {
-    tf::Transformer tf;
-
-    //tf.setTransform();
+    tf2_ros::Buffer tf;
 
     // create an interactive marker server on the topic namespace simple_marker
 
@@ -226,11 +222,11 @@ public:
       case Msg::TF_INFO:
       {
         DBG_MSG_STREAM( i << " TF_INFO: " << msg.frame_id << " -> " << target_frame << " at time " << msg.stamp.toSec() );
-        tf::StampedTransform stf;
-        stf.frame_id_=msg.frame_id;
-        stf.child_frame_id_=target_frame;
-        stf.stamp_=msg.stamp;
-        stf.setIdentity();
+        geometry_msgs::TransformStamped stf;
+        stf.header.frame_id = msg.frame_id;
+        stf.header.stamp = msg.stamp;
+        stf.child_frame_id = target_frame;
+        stf.transform.rotation.w = 1.0;
         tf.setTransform( stf, msg.server_id );
         break;
       }

--- a/src/test/missing_tf.cpp
+++ b/src/test/missing_tf.cpp
@@ -30,8 +30,8 @@
 
 #include <ros/ros.h>
 
-#include <tf/transform_broadcaster.h>
-#include <tf/tf.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <interactive_markers/interactive_marker_server.h>
 
@@ -128,7 +128,7 @@ void make6DofMarker( bool fixed )
 
 void frameCallback(const ros::TimerEvent&)
 {
-  static tf::TransformBroadcaster br;
+  static tf2_ros::TransformBroadcaster br;
   static bool sending = true;
 
   geometry_msgs::Pose pose;
@@ -159,10 +159,14 @@ void frameCallback(const ros::TimerEvent&)
   server->setPose("simple_6dof",pose,header);
   server->applyChanges();
 
-  tf::Transform t;
-  t.setOrigin(tf::Vector3(0.0, 0.0, 1.0));
-  t.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
-  br.sendTransform(tf::StampedTransform(t, time, "base_link", "bursty_frame"));
+  geometry_msgs::TransformStamped stf;
+  stf.header.frame_id = "base_link";
+  stf.header.stamp = time;
+  stf.child_frame_id = "bursty_frame";
+  stf.transform.translation = toMsg(tf2::Vector3(0.0, 0.0, 1.0));
+  stf.transform.rotation = toMsg(tf2::Quaternion(0.0, 0.0, 0.0, 1.0));
+
+  br.sendTransform(stf);
 }
 
 int main(int argc, char** argv)

--- a/src/test/server_client_test.cpp
+++ b/src/test/server_client_test.cpp
@@ -33,7 +33,7 @@
 
 #include <gtest/gtest.h>
 
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
 
 #include <interactive_markers/interactive_marker_server.h>
 #include <interactive_markers/interactive_marker_client.h>
@@ -112,7 +112,7 @@ void waitMsg()
 
 TEST(InteractiveMarkerServerAndClient, connect_tf_error)
 {
-  tf::TransformListener tf;
+  tf2_ros::Buffer buffer;
 
   // create an interactive marker server on the topic namespace simple_marker
   interactive_markers::InteractiveMarkerServer server("im_server_client_test","test_server",false);
@@ -124,7 +124,7 @@ TEST(InteractiveMarkerServerAndClient, connect_tf_error)
 
   resetReceivedMsgs();
 
-  interactive_markers::InteractiveMarkerClient client(tf, "valid_frame", "im_server_client_test");
+  interactive_markers::InteractiveMarkerClient client(buffer, "valid_frame", "im_server_client_test");
   client.setInitCb( &initCb );
   client.setStatusCb( &statusCb );
   client.setResetCb( &resetCb );

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -29,8 +29,8 @@
 
 #include "interactive_markers/tools.h"
 
-#include <tf/LinearMath/Quaternion.h>
-#include <tf/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
 
 #include <math.h>
 #include <assert.h>
@@ -63,8 +63,8 @@ void autoComplete( visualization_msgs::InteractiveMarker &msg, bool enable_autoc
   }
 
   //normalize quaternion
-  tf::Quaternion int_marker_orientation( msg.pose.orientation.x, msg.pose.orientation.y,
-      msg.pose.orientation.z, msg.pose.orientation.w );
+  tf2::Quaternion int_marker_orientation( msg.pose.orientation.x, msg.pose.orientation.y,
+                                          msg.pose.orientation.z, msg.pose.orientation.w );
   int_marker_orientation.normalize();
   msg.pose.orientation.x = int_marker_orientation.x();
   msg.pose.orientation.y = int_marker_orientation.y();
@@ -141,9 +141,9 @@ void autoComplete( const visualization_msgs::InteractiveMarker &msg,
   }
 
   // get interactive marker pose for later
-  tf::Quaternion int_marker_orientation( msg.pose.orientation.x, msg.pose.orientation.y,
-      msg.pose.orientation.z, msg.pose.orientation.w );
-  tf::Vector3 int_marker_position( msg.pose.position.x, msg.pose.position.y, msg.pose.position.z );
+  tf2::Quaternion int_marker_orientation( msg.pose.orientation.x, msg.pose.orientation.y,
+                                          msg.pose.orientation.z, msg.pose.orientation.w );
+  tf2::Vector3 int_marker_position( msg.pose.position.x, msg.pose.position.y, msg.pose.position.z );
 
   // fill in missing pose information into the markers
   for ( unsigned m=0; m<control.markers.size(); m++ )
@@ -173,8 +173,8 @@ void autoComplete( const visualization_msgs::InteractiveMarker &msg,
     }
 
     //normalize orientation
-    tf::Quaternion marker_orientation( marker.pose.orientation.x, marker.pose.orientation.y,
-        marker.pose.orientation.z, marker.pose.orientation.w );
+    tf2::Quaternion marker_orientation( marker.pose.orientation.x, marker.pose.orientation.y,
+                                        marker.pose.orientation.z, marker.pose.orientation.w );
 
     marker_orientation.normalize();
 
@@ -397,8 +397,8 @@ void assignDefaultColor(visualization_msgs::Marker &marker, const geometry_msgs:
 {
   geometry_msgs::Vector3 v;
 
-  tf::Quaternion bt_quat( quat.x, quat.y, quat.z, quat.w );
-  tf::Vector3 bt_x_axis = tf::Matrix3x3(bt_quat) * tf::Vector3(1,0,0);
+  tf2::Quaternion bt_quat( quat.x, quat.y, quat.z, quat.w );
+  tf2::Vector3 bt_x_axis = tf2::Matrix3x3(bt_quat) * tf2::Vector3(1,0,0);
 
   float x,y,z;
   x = fabs(bt_x_axis.x());


### PR DESCRIPTION
Before releasing into Noetic, I would like to migrate from tf1 to tf2. I think I managed all required changes, but I'm not sure how to correctly migrate [`getLatestCommonTime()`](https://github.com/ros-visualization/interactive_markers/blob/indigo-devel/src/message_context.cpp#L99).
The corresponding function in tf2 [is private](https://github.com/ros/geometry2/blob/ce75a9f1ee748eddfe33d694a4a42d3767052d17/tf2/include/tf2/buffer_core.h#L396) and the public alternative [`getLatestCommonTime()`](https://github.com/ros/geometry2/blob/ce75a9f1ee748eddfe33d694a4a42d3767052d17/tf2/include/tf2/buffer_core.h#L285), which I used for now, is [marked as reserved for tf1 compatibility](https://github.com/ros/geometry2/blob/ce75a9f1ee748eddfe33d694a4a42d3767052d17/tf2/include/tf2/buffer_core.h#L250). @tfoote, can you provide a hint? Should the function become public?
