### PR TITLE
Remove explicit template parameter in `spin_until_future_complete`

### DIFF
--- a/test/interactive_markers/test_interactive_marker_server.cpp
+++ b/test/interactive_markers/test_interactive_marker_server.cpp
@@ -367,8 +367,7 @@ TEST_F(TestInteractiveMarkerServerWithMarkers, get_interactive_markers_communica
   using namespace std::chrono_literals;
 
   MockInteractiveMarkerClient::SharedFuture future = mock_client_->requestInteractiveMarkers();
-  auto ret = executor_.spin_until_future_complete<MockInteractiveMarkerClient::SharedFuture>(
-    future, 3000ms);
+  auto ret = executor_.spin_until_future_complete(future, 3000ms);
   ASSERT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
   visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr response = future.get();
   ASSERT_EQ(response->markers.size(), markers_.size());

--- a/test/interactive_markers/test_interactive_marker_server.cpp
+++ b/test/interactive_markers/test_interactive_marker_server.cpp
@@ -367,7 +367,7 @@ TEST_F(TestInteractiveMarkerServerWithMarkers, get_interactive_markers_communica
   using namespace std::chrono_literals;
 
   MockInteractiveMarkerClient::SharedFuture future = mock_client_->requestInteractiveMarkers();
-  auto ret = executor_.spin_until_future_complete<MockInteractiveMarkerClient::SharedResponse>(
+  auto ret = executor_.spin_until_future_complete<MockInteractiveMarkerClient::SharedFuture>(
     future, 3000ms);
   ASSERT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
   visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr response = future.get();


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>

As per https://github.com/ros2/rclcpp/issues/972 and https://github.com/ros2/rclcpp/pull/1113, `spin_until_future_complete` should be able to accept both `std::future` and `std::shared_future`. This is the only downstream error blocking the original PR, I believe making the fix here is a better option.