### PR TITLE
[foxy backport] Remove explicit template parameter in `spin_until_future_complete` (#72)

### DIFF
--- a/test/interactive_markers/test_interactive_marker_server.cpp
+++ b/test/interactive_markers/test_interactive_marker_server.cpp
@@ -367,8 +367,7 @@ TEST_F(TestInteractiveMarkerServerWithMarkers, get_interactive_markers_communica
   using namespace std::chrono_literals;
 
   MockInteractiveMarkerClient::SharedFuture future = mock_client_->requestInteractiveMarkers();
-  auto ret = executor_.spin_until_future_complete<MockInteractiveMarkerClient::SharedResponse>(
-    future, 3000ms);
+  auto ret = executor_.spin_until_future_complete(future, 3000ms);
   ASSERT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
   visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr response = future.get();
   ASSERT_EQ(response->markers.size(), markers_.size());


### PR DESCRIPTION
Backport #72 to Foxy

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11074)](http://ci.ros2.org/job/ci_linux/11074/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6388)](http://ci.ros2.org/job/ci_linux-aarch64/6388/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9030)](http://ci.ros2.org/job/ci_osx/9030/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10990)](http://ci.ros2.org/job/ci_windows/10990/)

I plan to fast-forward merge.