### PR TITLE
[ROS 2] fix clang warnings

### DIFF
--- a/include/interactive_markers/message_context.hpp
+++ b/include/interactive_markers/message_context.hpp
@@ -62,6 +62,8 @@ public:
     typename MsgT::SharedPtr msg,
     bool enable_autocomplete_transparency = true);
 
+  MessageContext(const MessageContext &) = default;
+
   MessageContext<MsgT> & operator=(const MessageContext<MsgT> & other);
 
   // transform all messages with timestamp into target frame

--- a/test/interactive_markers/test_interactive_marker_server.cpp
+++ b/test/interactive_markers/test_interactive_marker_server.cpp
@@ -93,7 +93,7 @@ TEST(TestInteractiveMarkerServer, insert)
 
   // Insert some markers
   std::vector<visualization_msgs::msg::InteractiveMarker> markers = get_interactive_markers();
-  for (const auto marker : markers) {
+  for (const auto & marker : markers) {
     server.insert(marker);
   }
 
@@ -130,7 +130,7 @@ protected:
 
     // Insert some markers
     markers_ = get_interactive_markers();
-    for (const auto marker : markers_) {
+    for (const auto & marker : markers_) {
       server_->insert(marker);
     }
     server_->applyChanges();
@@ -205,7 +205,7 @@ TEST_F(TestInteractiveMarkerServerWithMarkers, clear)
 TEST_F(TestInteractiveMarkerServerWithMarkers, get_marker_by_name)
 {
   // Get markers
-  for (const auto input_marker : markers_) {
+  for (const auto & input_marker : markers_) {
     visualization_msgs::msg::InteractiveMarker output_marker;
     EXPECT_TRUE(server_->get(input_marker.name, output_marker));
     EXPECT_EQ(output_marker.header.frame_id, input_marker.header.frame_id);


### PR DESCRIPTION
Before:
* https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/482/gcc/folder.328841394/
* https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/482/gcc/folder.1959303106/

After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11461)](https://ci.ros2.org/job/ci_linux/11461/)
  * only unrelated warnings remaining

Regular CI builds testing the downstream packages (only with FastRTPS):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11463)](http://ci.ros2.org/job/ci_linux/11463/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6670)](http://ci.ros2.org/job/ci_linux-aarch64/6670/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9399)](http://ci.ros2.org/job/ci_osx/9399/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11358)](http://ci.ros2.org/job/ci_windows/11358/)