### PR TITLE
Enable private names for InteractiveMarkerServer

### DIFF
--- a/include/interactive_markers/interactive_marker_server.h
+++ b/include/interactive_markers/interactive_marker_server.h
@@ -63,15 +63,15 @@ public:
 
   static const uint8_t DEFAULT_FEEDBACK_CB = 255;
 
-  /// @param topic_ns      The interface will use the topics topic_ns/update and
-  ///                      topic_ns/feedback for communication.
+  /// @param node_ns     Namespace of the server node. The interface will use the topics update and
+  ///                      feedback for communication.
   /// @param server_id     If you run multiple servers on the same topic from
   ///                      within the same node, you will need to assign different names to them.
   ///                      Otherwise, leave this empty.
   /// @param spin_thread   If set to true, will spin up a thread for message handling.
   ///                      All callbacks will be called from that thread.
   INTERACTIVE_MARKERS_PUBLIC
-  InteractiveMarkerServer( const std::string &topic_ns, const std::string &server_id="", bool spin_thread = false );
+  InteractiveMarkerServer( const std::string &node_ns, const std::string &server_id="", bool spin_thread = false );
 
   /// Destruction of the interface will lead to all managed markers being cleared.
   INTERACTIVE_MARKERS_PUBLIC

--- a/src/interactive_marker_server.cpp
+++ b/src/interactive_marker_server.cpp
@@ -39,8 +39,8 @@
 namespace interactive_markers
 {
 
-InteractiveMarkerServer::InteractiveMarkerServer( const std::string &topic_ns, const std::string &server_id, bool spin_thread ) :
-    topic_ns_(topic_ns),
+InteractiveMarkerServer::InteractiveMarkerServer( const std::string &node_ns, const std::string &server_id, bool spin_thread ) :
+    node_handle_(node_ns),
     seq_num_(0)
 {
   if ( spin_thread )
@@ -58,9 +58,9 @@ InteractiveMarkerServer::InteractiveMarkerServer( const std::string &topic_ns, c
     server_id_ = ros::this_node::getName();
   }
 
-  std::string update_topic = topic_ns + "/update";
+  std::string update_topic = "update";
   std::string init_topic = update_topic + "_full";
-  std::string feedback_topic = topic_ns + "/feedback";
+  std::string feedback_topic = "feedback";
 
   init_pub_ = node_handle_.advertise<visualization_msgs::InteractiveMarkerInit>( init_topic, 100, true );
   update_pub_ = node_handle_.advertise<visualization_msgs::InteractiveMarkerUpdate>( update_topic, 100 );


### PR DESCRIPTION
remove topic_ns member and instead pass the parameter to the node_handle constructor
This enables to use Private Names e.g.
`interactive_markers::InteractiveMarkerServer marker_server("~/name")`

