### PR TITLE
Fix deprecated sub callback warnings

### DIFF
--- a/include/interactive_markers/interactive_marker_client.hpp
+++ b/include/interactive_markers/interactive_marker_client.hpp
@@ -282,7 +282,7 @@ private:
     rclcpp::Client<visualization_msgs::srv::GetInteractiveMarkers>::SharedFuture future);
 
   void processUpdate(
-    visualization_msgs::msg::InteractiveMarkerUpdate::SharedPtr msg);
+    visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr msg);
 
   bool transformInitialMessage();
 

--- a/include/interactive_markers/interactive_marker_server.hpp
+++ b/include/interactive_markers/interactive_marker_server.hpp
@@ -254,7 +254,8 @@ private:
     std::shared_ptr<visualization_msgs::srv::GetInteractiveMarkers::Response> response);
 
   // update marker pose & call user callback
-  void processFeedback(visualization_msgs::msg::InteractiveMarkerFeedback::SharedPtr feedback);
+  void processFeedback(
+    visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr feedback);
 
   // increase sequence number & publish an update
   void publish(visualization_msgs::msg::InteractiveMarkerUpdate & update);

--- a/include/interactive_markers/message_context.hpp
+++ b/include/interactive_markers/message_context.hpp
@@ -55,7 +55,7 @@ public:
   MessageContext(
     std::shared_ptr<tf2::BufferCoreInterface> tf_buffer_core,
     const std::string & target_frame,
-    typename MsgT::SharedPtr msg,
+    typename MsgT::ConstSharedPtr msg,
     bool enable_autocomplete_transparency = true);
 
   MessageContext(const MessageContext &) = default;

--- a/src/interactive_marker_client.cpp
+++ b/src/interactive_marker_client.cpp
@@ -242,7 +242,7 @@ void InteractiveMarkerClient::processInitialMessage(
 }
 
 void InteractiveMarkerClient::processUpdate(
-  visualization_msgs::msg::InteractiveMarkerUpdate::SharedPtr msg)
+  visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr msg)
 {
   // Ignore legacy "keep alive" messages
   if (msg->type == msg->KEEP_ALIVE) {

--- a/src/interactive_marker_server.cpp
+++ b/src/interactive_marker_server.cpp
@@ -384,7 +384,7 @@ void InteractiveMarkerServer::getInteractiveMarkersCallback(
 }
 
 void InteractiveMarkerServer::processFeedback(
-  visualization_msgs::msg::InteractiveMarkerFeedback::SharedPtr feedback)
+  visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr feedback)
 {
   std::unique_lock<std::recursive_mutex> lock(mutex_);
 

--- a/src/message_context.cpp
+++ b/src/message_context.cpp
@@ -52,7 +52,7 @@ template<class MsgT>
 MessageContext<MsgT>::MessageContext(
   std::shared_ptr<tf2::BufferCoreInterface> tf_buffer_core,
   const std::string & target_frame,
-  typename MsgT::SharedPtr _msg,
+  typename MsgT::ConstSharedPtr _msg,
   bool enable_autocomplete_transparency)
 : tf_buffer_core_(tf_buffer_core),
   target_frame_(target_frame),

--- a/test/interactive_markers/mock_interactive_marker_client.hpp
+++ b/test/interactive_markers/mock_interactive_marker_client.hpp
@@ -55,7 +55,7 @@ public:
   SharedFuture requestInteractiveMarkers();
 
   uint32_t updates_received;
-  visualization_msgs::msg::InteractiveMarkerUpdate::SharedPtr last_update_message;
+  visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr last_update_message;
   visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr last_response_message;
 
   std::string topic_namespace_;
@@ -81,7 +81,7 @@ MockInteractiveMarkerClient::MockInteractiveMarkerClient(
   subscription_ = create_subscription<visualization_msgs::msg::InteractiveMarkerUpdate>(
     topic_namespace_ + "/update",
     1,
-    [this](const visualization_msgs::msg::InteractiveMarkerUpdate::SharedPtr update)
+    [this](const visualization_msgs::msg::InteractiveMarkerUpdate::ConstSharedPtr update)
     {
       RCLCPP_INFO(this->get_logger(), "Update received");
       ++this->updates_received;

--- a/test/interactive_markers/mock_interactive_marker_server.hpp
+++ b/test/interactive_markers/mock_interactive_marker_server.hpp
@@ -93,7 +93,7 @@ MockInteractiveMarkerServer::MockInteractiveMarkerServer(
   subscription_ = create_subscription<visualization_msgs::msg::InteractiveMarkerFeedback>(
     topic_namespace_ + "/feedback",
     10,
-    [this](const visualization_msgs::msg::InteractiveMarkerFeedback::SharedPtr feedback)
+    [this](const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr feedback)
     {
       (void)feedback;
       RCLCPP_INFO(this->get_logger(), "Feedback received");


### PR DESCRIPTION
ros2/rclcpp#1713 deprecates the `void shared_ptr<T>` subscription callback signatures, so this PR migrates away from said signatures.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>