### PR TITLE
Install includes to include/${PROJECT_NAME} and misc CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,22 +29,21 @@ add_library(${PROJECT_NAME} SHARED
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
-ament_target_dependencies(${PROJECT_NAME}
-  "rclcpp"
-  "rmw"
-  "tf2"
-  "tf2_geometry_msgs"
-  "visualization_msgs")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rclcpp::rclcpp
+  tf2::tf2
+  ${visualization_msgs_TARGETS})
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  rmw::rmw
+  ${tf2_geometry_msgs_TARGETS})
 
-install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-install(
-  DIRECTORY include/
-  DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -52,19 +51,14 @@ target_compile_definitions(${PROJECT_NAME}
   PRIVATE "INTERACTIVE_MARKERS_BUILDING_LIBRARY")
 
 ament_export_dependencies("rclcpp")
-ament_export_dependencies("rmw")
 ament_export_dependencies("tf2")
-ament_export_dependencies("tf2_geometry_msgs")
 ament_export_dependencies("visualization_msgs")
-ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(geometry_msgs REQUIRED)
-  find_package(std_msgs REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
 
@@ -72,27 +66,16 @@ if(BUILD_TESTING)
     test/${PROJECT_NAME}/test_interactive_marker_server.cpp
     TIMEOUT 90
   )
-  ament_target_dependencies(test_interactive_marker_server
-    "geometry_msgs"
-    "rclcpp"
-    "std_msgs"
-  )
   target_link_libraries(test_interactive_marker_server
     ${PROJECT_NAME}
-  )
+    ${geometry_msgs_TARGETS})
 
   ament_add_gtest(test_interactive_marker_client
     test/${PROJECT_NAME}/test_interactive_marker_client.cpp
   )
-  ament_target_dependencies(test_interactive_marker_client
-    "geometry_msgs"
-    "rclcpp"
-    "std_msgs"
-    "tf2"
-  )
   target_link_libraries(test_interactive_marker_client
     ${PROJECT_NAME}
-  )
+    ${geometry_msgs_TARGETS})
 endif()
 
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,6 @@
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Part of ros2/ros2#1150

This installs includes to `include/${PROJECT_NAME}` to mitigate include directory search order issues when overriding packages in desktop.

Part of ament/ament_cmake#365

This removes `ament_export_libraries` and `ament_export_include_directories` as they're redundant with the exported CMake targets.

Part of ament/ament_cmake#292

This replaces `ament_target_dependencies()` calls with `target_link_libraries()`.

I also removed the unused dependency on `std_msgs` from the `package.xml`.