### PR TITLE
Deprecated spin_until_future_complete

### DIFF
--- a/test/interactive_markers/test_interactive_marker_server.cpp
+++ b/test/interactive_markers/test_interactive_marker_server.cpp
@@ -364,7 +364,7 @@ TEST_F(TestInteractiveMarkerServerWithMarkers, get_interactive_markers_communica
   using namespace std::chrono_literals;
 
   auto future = mock_client_->requestInteractiveMarkers();
-  auto ret = executor_.spin_until_future_complete(future, 3000ms);
+  auto ret = executor_.spin_until_complete(future, 3000ms);
   ASSERT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
   visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr response = future.get();
   ASSERT_EQ(response->markers.size(), markers_.size());


### PR DESCRIPTION
Replace deprecated `spin_until_future_complete` with `spin_until_complete`

Signed-off-by: Hubert Liberacki <hliberacki@gmail.com>