### PR TITLE
Make compatible with service introspection

### DIFF
--- a/include/interactive_markers/interactive_marker_client.hpp
+++ b/include/interactive_markers/interactive_marker_client.hpp
@@ -129,13 +129,14 @@ public:
     const std::string & topic_namespace = "",
     const std::chrono::duration<Rep, Period> & request_timeout = std::chrono::seconds(1),
     const rclcpp::QoS & update_sub_qos = rclcpp::QoS(100),
-    const rclcpp::QoS & feedback_pub_qos = rclcpp::QoS(100))
+    const rclcpp::QoS & feedback_pub_qos = rclcpp::QoS(100),
+    bool enable_service_introspection = false)
   : node_base_interface_(node_base_interface),
     topics_interface_(topics_interface),
     services_interface_(services_interface),
     graph_interface_(graph_interface),
     client_id_(node_base_interface->get_fully_qualified_name()),
-    clock_(clock_interface->get_clock()),
+    clock_interface_(clock_interface),
     logger_(logging_interface->get_logger()),
     state_(STATE_IDLE),
     tf_buffer_core_(tf_buffer_core),
@@ -147,7 +148,8 @@ public:
     initial_response_msg_(0),
     first_update_(true),
     last_update_sequence_number_(0u),
-    enable_autocomplete_transparency_(true)
+    enable_autocomplete_transparency_(true),
+    enable_service_introspection_(true)
   {
     connect(topic_namespace_);
   }
@@ -301,10 +303,9 @@ private:
   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr topics_interface_;
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr services_interface_;
   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr graph_interface_;
+  rclcpp::node_interfaces::NodeClockInterface::SharedPtr clock_interface_;
 
   std::string client_id_;
-
-  rclcpp::Clock::SharedPtr clock_;
 
   rclcpp::Logger logger_;
 
@@ -348,6 +349,9 @@ private:
 
   // if false, auto-completed markers will have alpha = 1.0
   bool enable_autocomplete_transparency_;
+
+  // enable/disable service introspection
+  bool enable_service_introspection_;
 
   // User callbacks
   InitializeCallback initialize_callback_;

--- a/include/interactive_markers/interactive_marker_server.hpp
+++ b/include/interactive_markers/interactive_marker_server.hpp
@@ -83,7 +83,8 @@ public:
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr topics_interface,
     rclcpp::node_interfaces::NodeServicesInterface::SharedPtr services_interface,
     const rclcpp::QoS & update_pub_qos = rclcpp::QoS(100),
-    const rclcpp::QoS & feedback_sub_qos = rclcpp::QoS(1));
+    const rclcpp::QoS & feedback_sub_qos = rclcpp::QoS(1),
+    bool enable_service_introspection=false);
 
   template<typename NodePtr>
   InteractiveMarkerServer(
@@ -99,7 +100,8 @@ public:
       node->get_node_topics_interface(),
       node->get_node_services_interface(),
       update_pub_qos,
-      feedback_sub_qos)
+      feedback_sub_qos,
+      node->get_node_options().enable_service_introspection())
   {
   }
 

--- a/src/interactive_marker_client.cpp
+++ b/src/interactive_marker_client.cpp
@@ -69,9 +69,11 @@ void InteractiveMarkerClient::connect(std::string topic_namespace)
       node_base_interface_,
       graph_interface_,
       services_interface_,
+      clock_interface_,
       topic_namespace_ + "/get_interactive_markers",
       rmw_qos_profile_services_default,
-      nullptr);
+      nullptr,
+      enable_service_introspection_);
 
     feedback_pub_ = rclcpp::create_publisher<visualization_msgs::msg::InteractiveMarkerFeedback>(
       topics_interface_,
@@ -226,7 +228,7 @@ void InteractiveMarkerClient::requestInteractiveMarkers()
   get_interactive_markers_client_->async_send_request(
     request,
     callback);
-  request_time_ = clock_->now();
+  request_time_ = clock_interface_->get_clock()->now();
 }
 
 void InteractiveMarkerClient::processInitialMessage(
@@ -323,7 +325,7 @@ bool InteractiveMarkerClient::checkInitializeFinished()
   std::unique_lock<std::recursive_mutex> lock(mutex_);
   if (!initial_response_msg_) {
     // We haven't received a response yet, check for timeout
-    if ((clock_->now() - request_time_) > request_timeout_) {
+    if ((clock_interface_->get_clock()->now() - request_time_) > request_timeout_) {
       updateStatus(
         STATUS_WARN, "Did not receive response with interactive markers, resending request...");
       requestInteractiveMarkers();

--- a/src/interactive_marker_server.cpp
+++ b/src/interactive_marker_server.cpp
@@ -53,7 +53,8 @@ InteractiveMarkerServer::InteractiveMarkerServer(
   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr topics_interface,
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr services_interface,
   const rclcpp::QoS & update_pub_qos,
-  const rclcpp::QoS & feedback_sub_qos)
+  const rclcpp::QoS & feedback_sub_qos,
+  bool enable_service_introspection)
 : topic_namespace_(topic_namespace),
   context_(base_interface->get_context()),
   clock_(clock_interface->get_clock()),
@@ -67,6 +68,7 @@ InteractiveMarkerServer::InteractiveMarkerServer(
     visualization_msgs::srv::GetInteractiveMarkers>(
     base_interface,
     services_interface,
+    clock_interface,
     topic_namespace + "/get_interactive_markers",
     std::bind(
       &InteractiveMarkerServer::getInteractiveMarkersCallback,
@@ -75,7 +77,8 @@ InteractiveMarkerServer::InteractiveMarkerServer(
       std::placeholders::_2,
       std::placeholders::_3),
     rmw_qos_profile_services_default,
-    base_interface->get_default_callback_group());
+    base_interface->get_default_callback_group(),
+    enable_service_introspection);
 
   update_pub_ = rclcpp::create_publisher<InteractiveMarkerUpdate>(
     topics_interface, update_topic, update_pub_qos);


### PR DESCRIPTION
This PR updates the `rclcpp::create_{client, service}` calls in this repo to pass the node clock interface as required by the new service introspection feature. https://github.com/ros2/ros2/issues/1285 

To accomodate this change `interactive_marker_client` is also updated to maintain a reference to the node clock interface instead of the clock directly.

Signed-off-by: Brian Chen <brian.chen@openrobotics.org>