### PR TITLE
Cleanup of interactive markers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   ${visualization_msgs_TARGETS})
 target_link_libraries(${PROJECT_NAME} PRIVATE
   rmw::rmw
-  ${tf2_geometry_msgs_TARGETS})
+  tf2_geometry_msgs::tf2_geometry_msgs)
 
 install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,6 @@ if(BUILD_TESTING)
   add_library(interactive_marker_fixtures
     test/${PROJECT_NAME}/interactive_marker_fixtures.cpp
   )
-  target_include_directories(interactive_marker_fixtures PRIVATE
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
   target_link_libraries(interactive_marker_fixtures PRIVATE
     ${visualization_msgs_TARGETS}
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,11 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
@@ -32,7 +35,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${geometry_msgs_TARGETS}
   rclcpp::rclcpp
+  rcutils::rcutils
+  ${std_msgs_TARGETS}
   tf2::tf2
   ${visualization_msgs_TARGETS})
 target_link_libraries(${PROJECT_NAME} PRIVATE
@@ -51,15 +57,19 @@ install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE "INTERACTIVE_MARKERS_BUILDING_LIBRARY")
 
-ament_export_dependencies("rclcpp")
-ament_export_dependencies("tf2")
-ament_export_dependencies("visualization_msgs")
+ament_export_dependencies(
+  "geometry_msgs"
+  "rclcpp"
+  "std_msgs"
+  "tf2"
+  "visualization_msgs"
+)
 ament_export_targets(export_${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
-  find_package(geometry_msgs REQUIRED)
+  find_package(builtin_interfaces REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,15 +73,13 @@ if(BUILD_TESTING)
 
   ament_lint_auto_find_test_dependencies()
 
-  add_library(interactive_marker_fixtures SHARED
+  add_library(interactive_marker_fixtures
     test/${PROJECT_NAME}/interactive_marker_fixtures.cpp
   )
-  target_compile_definitions(interactive_marker_fixtures
-    PRIVATE "INTERACTIVE_MARKERS_BUILDING_LIBRARY")
-  target_include_directories(interactive_marker_fixtures PUBLIC
+  target_include_directories(interactive_marker_fixtures PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-  target_link_libraries(interactive_marker_fixtures PUBLIC
+  target_link_libraries(interactive_marker_fixtures PRIVATE
     ${visualization_msgs_TARGETS}
   )
 
@@ -99,7 +97,6 @@ if(BUILD_TESTING)
   )
 
   ament_add_gtest(test_interactive_marker_client
-    test/${PROJECT_NAME}/interactive_marker_fixtures.cpp
     test/${PROJECT_NAME}/test_interactive_marker_client.cpp
   )
   target_link_libraries(test_interactive_marker_client

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,8 @@ if(BUILD_TESTING)
   add_library(interactive_marker_fixtures SHARED
     test/${PROJECT_NAME}/interactive_marker_fixtures.cpp
   )
+  target_compile_definitions(interactive_marker_fixtures
+    PRIVATE "INTERACTIVE_MARKERS_BUILDING_LIBRARY")
   target_include_directories(interactive_marker_fixtures PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,20 +73,42 @@ if(BUILD_TESTING)
 
   ament_lint_auto_find_test_dependencies()
 
+  add_library(interactive_marker_fixtures SHARED
+    test/${PROJECT_NAME}/interactive_marker_fixtures.cpp
+  )
+  target_include_directories(interactive_marker_fixtures PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+  target_link_libraries(interactive_marker_fixtures PUBLIC
+    ${visualization_msgs_TARGETS}
+  )
+
   ament_add_gtest(test_interactive_marker_server
     test/${PROJECT_NAME}/test_interactive_marker_server.cpp
     TIMEOUT 90
   )
   target_link_libraries(test_interactive_marker_server
     ${PROJECT_NAME}
-    ${geometry_msgs_TARGETS})
+    interactive_marker_fixtures
+    ${geometry_msgs_TARGETS}
+    rclcpp::rclcpp
+    ${std_msgs_TARGETS}
+    ${visualization_msgs_TARGETS}
+  )
 
   ament_add_gtest(test_interactive_marker_client
+    test/${PROJECT_NAME}/interactive_marker_fixtures.cpp
     test/${PROJECT_NAME}/test_interactive_marker_client.cpp
   )
   target_link_libraries(test_interactive_marker_client
     ${PROJECT_NAME}
-    ${geometry_msgs_TARGETS})
+    interactive_marker_fixtures
+    ${builtin_interfaces_TARGETS}
+    ${geometry_msgs_TARGETS}
+    rclcpp::rclcpp
+    tf2::tf2
+    ${visualization_msgs_TARGETS}
+  )
 endif()
 
 ament_package()

--- a/include/interactive_markers/interactive_marker_client.hpp
+++ b/include/interactive_markers/interactive_marker_client.hpp
@@ -197,7 +197,7 @@ public:
 
   /// Connect to a server in a given namespace.
   INTERACTIVE_MARKERS_PUBLIC
-  void connect(std::string topic_namespace);
+  void connect(const std::string & topic_namespace);
 
   /// Disconnect from a server and clear the update queue.
   INTERACTIVE_MARKERS_PUBLIC
@@ -216,7 +216,7 @@ public:
    * This resets the connection.
    */
   INTERACTIVE_MARKERS_PUBLIC
-  void setTargetFrame(std::string target_frame);
+  void setTargetFrame(const std::string & target_frame);
 
   /// Set the initialization callback.
   /**

--- a/include/interactive_markers/interactive_marker_client.hpp
+++ b/include/interactive_markers/interactive_marker_client.hpp
@@ -36,11 +36,13 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <ratio>
 #include <string>
-#include <unordered_map>
 
 #include "rclcpp/logger.hpp"
 #include "rclcpp/rclcpp.hpp"
+
+#include "tf2/buffer_core_interface.h"
 
 #include "visualization_msgs/msg/interactive_marker_feedback.hpp"
 #include "visualization_msgs/msg/interactive_marker_update.hpp"
@@ -48,11 +50,6 @@
 
 #include "interactive_markers/message_context.hpp"
 #include "interactive_markers/visibility_control.hpp"
-
-namespace tf2
-{
-class BufferCoreInterface;
-}
 
 namespace interactive_markers
 {

--- a/include/interactive_markers/interactive_marker_server.hpp
+++ b/include/interactive_markers/interactive_marker_server.hpp
@@ -216,7 +216,7 @@ public:
    * \return true if a marker with the provided name exists, false otherwise.
    */
   INTERACTIVE_MARKERS_PUBLIC
-  bool get(std::string name, visualization_msgs::msg::InteractiveMarker & int_marker) const;
+  bool get(const std::string & name, visualization_msgs::msg::InteractiveMarker & int_marker) const;
 
 private:
   // Disable copying

--- a/include/interactive_markers/interactive_marker_server.hpp
+++ b/include/interactive_markers/interactive_marker_server.hpp
@@ -36,10 +36,12 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <thread>
 #include <unordered_map>
 
 #include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/pose.hpp"
+#include "std_msgs/msg/header.hpp"
+#include "visualization_msgs/msg/interactive_marker.hpp"
 #include "visualization_msgs/msg/interactive_marker_feedback.hpp"
 #include "visualization_msgs/msg/interactive_marker_update.hpp"
 #include "visualization_msgs/srv/get_interactive_markers.hpp"

--- a/include/interactive_markers/menu_handler.hpp
+++ b/include/interactive_markers/menu_handler.hpp
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "visualization_msgs/msg/interactive_marker_feedback.hpp"
 #include "visualization_msgs/msg/menu_entry.hpp"
 
 #include "interactive_markers/interactive_marker_server.hpp"

--- a/include/interactive_markers/message_context.hpp
+++ b/include/interactive_markers/message_context.hpp
@@ -37,13 +37,12 @@
 #include <string>
 #include <vector>
 
-#include "visualization_msgs/msg/interactive_marker_init.hpp"
-#include "visualization_msgs/msg/interactive_marker_update.hpp"
+#include "tf2/buffer_core_interface.h"
 
-namespace tf2
-{
-class BufferCoreInterface;
-}
+#include "geometry_msgs/msg/pose.hpp"
+#include "std_msgs/msg/header.hpp"
+#include "visualization_msgs/msg/interactive_marker.hpp"
+#include "visualization_msgs/msg/interactive_marker_pose.hpp"
 
 namespace interactive_markers
 {

--- a/include/interactive_markers/tools.hpp
+++ b/include/interactive_markers/tools.hpp
@@ -108,7 +108,7 @@ INTERACTIVE_MARKERS_PUBLIC
 void makeViewFacingButton(
   const visualization_msgs::msg::InteractiveMarker & msg,
   visualization_msgs::msg::InteractiveMarkerControl & control,
-  std::string text);
+  const std::string & text);
 
 /// Assign an RGB value to the given marker based on the given orientation.
 /**

--- a/include/interactive_markers/tools.hpp
+++ b/include/interactive_markers/tools.hpp
@@ -31,7 +31,10 @@
 
 #include <string>
 
+#include "geometry_msgs/msg/quaternion.hpp"
 #include "visualization_msgs/msg/interactive_marker.hpp"
+#include "visualization_msgs/msg/interactive_marker_control.hpp"
+#include "visualization_msgs/msg/marker.hpp"
 
 #include "interactive_markers/visibility_control.hpp"
 

--- a/package.xml
+++ b/package.xml
@@ -19,8 +19,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rcutils</depend>
   <depend>rmw</depend>
+  <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>
@@ -31,7 +34,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>geometry_msgs</test_depend>
+  <test_depend>builtin_interfaces</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/interactive_marker_client.cpp
+++ b/src/interactive_marker_client.cpp
@@ -58,7 +58,7 @@ InteractiveMarkerClient::~InteractiveMarkerClient()
 {
 }
 
-void InteractiveMarkerClient::connect(std::string topic_namespace)
+void InteractiveMarkerClient::connect(const std::string & topic_namespace)
 {
   changeState(STATE_IDLE);
   topic_namespace_ = topic_namespace;
@@ -170,7 +170,7 @@ void InteractiveMarkerClient::update()
   }
 }
 
-void InteractiveMarkerClient::setTargetFrame(std::string target_frame)
+void InteractiveMarkerClient::setTargetFrame(const std::string & target_frame)
 {
   if (target_frame_ == target_frame) {
     return;

--- a/src/interactive_marker_client.cpp
+++ b/src/interactive_marker_client.cpp
@@ -47,8 +47,6 @@
 #include "interactive_markers/exceptions.hpp"
 #include "interactive_markers/interactive_marker_client.hpp"
 
-using namespace std::placeholders;
-
 namespace interactive_markers
 {
 
@@ -90,7 +88,7 @@ void InteractiveMarkerClient::connect(const std::string & topic_namespace)
       topics_interface_,
       topic_namespace_ + "/update",
       update_sub_qos_,
-      std::bind(&InteractiveMarkerClient::processUpdate, this, _1));
+      std::bind(&InteractiveMarkerClient::processUpdate, this, std::placeholders::_1));
   } catch (rclcpp::exceptions::InvalidNodeError & ex) {
     updateStatus(STATUS_ERROR, "Failed to connect: " + std::string(ex.what()));
     disconnect();
@@ -229,7 +227,8 @@ void InteractiveMarkerClient::requestInteractiveMarkers()
   }
   updateStatus(STATUS_INFO, "Sending request for interactive markers");
 
-  auto callback = std::bind(&InteractiveMarkerClient::processInitialMessage, this, _1);
+  auto callback = std::bind(
+    &InteractiveMarkerClient::processInitialMessage, this, std::placeholders::_1);
   auto request = std::make_shared<visualization_msgs::srv::GetInteractiveMarkers::Request>();
   get_interactive_markers_client_->async_send_request(
     request,

--- a/src/interactive_marker_client.cpp
+++ b/src/interactive_marker_client.cpp
@@ -89,11 +89,11 @@ void InteractiveMarkerClient::connect(const std::string & topic_namespace)
       topic_namespace_ + "/update",
       update_sub_qos_,
       std::bind(&InteractiveMarkerClient::processUpdate, this, std::placeholders::_1));
-  } catch (rclcpp::exceptions::InvalidNodeError & ex) {
+  } catch (const rclcpp::exceptions::InvalidNodeError & ex) {
     updateStatus(STATUS_ERROR, "Failed to connect: " + std::string(ex.what()));
     disconnect();
     return;
-  } catch (rclcpp::exceptions::NameValidationError & ex) {
+  } catch (const rclcpp::exceptions::NameValidationError & ex) {
     updateStatus(STATUS_ERROR, "Failed to connect: " + std::string(ex.what()));
     disconnect();
     return;

--- a/src/interactive_marker_client.cpp
+++ b/src/interactive_marker_client.cpp
@@ -29,11 +29,19 @@
 
 // Author: David Gossow
 
+#include <chrono>
+#include <functional>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <utility>
 
+#include "rclcpp/rclcpp.hpp"
+#include "rmw/qos_profiles.h"
+
+#include "visualization_msgs/msg/interactive_marker_feedback.hpp"
+#include "visualization_msgs/msg/interactive_marker_update.hpp"
 #include "visualization_msgs/srv/get_interactive_markers.hpp"
 
 #include "interactive_markers/exceptions.hpp"

--- a/src/interactive_marker_server.cpp
+++ b/src/interactive_marker_server.cpp
@@ -29,7 +29,9 @@
 
 // Author: David Gossow
 
+#include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -37,10 +39,15 @@
 #include "interactive_markers/interactive_marker_server.hpp"
 
 #include "rmw/rmw.h"
-#include "rclcpp/qos.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-using visualization_msgs::msg::InteractiveMarkerFeedback;
-using visualization_msgs::msg::InteractiveMarkerUpdate;
+#include "geometry_msgs/msg/pose.hpp"
+#include "std_msgs/msg/header.hpp"
+#include "visualization_msgs/msg/interactive_marker.hpp"
+#include "visualization_msgs/msg/interactive_marker_feedback.hpp"
+#include "visualization_msgs/msg/interactive_marker_pose.hpp"
+#include "visualization_msgs/msg/interactive_marker_update.hpp"
+#include "visualization_msgs/srv/get_interactive_markers.hpp"
 
 namespace interactive_markers
 {

--- a/src/interactive_marker_server.cpp
+++ b/src/interactive_marker_server.cpp
@@ -84,10 +84,10 @@ InteractiveMarkerServer::InteractiveMarkerServer(
     rmw_qos_profile_services_default,
     base_interface->get_default_callback_group());
 
-  update_pub_ = rclcpp::create_publisher<InteractiveMarkerUpdate>(
+  update_pub_ = rclcpp::create_publisher<visualization_msgs::msg::InteractiveMarkerUpdate>(
     topics_interface, update_topic, update_pub_qos);
 
-  feedback_sub_ = rclcpp::create_subscription<InteractiveMarkerFeedback>(
+  feedback_sub_ = rclcpp::create_subscription<visualization_msgs::msg::InteractiveMarkerFeedback>(
     topics_interface,
     feedback_topic,
     feedback_sub_qos,

--- a/src/interactive_marker_server.cpp
+++ b/src/interactive_marker_server.cpp
@@ -331,7 +331,7 @@ void InteractiveMarkerServer::insert(
 }
 
 bool InteractiveMarkerServer::get(
-  std::string name,
+  const std::string & name,
   visualization_msgs::msg::InteractiveMarker & marker) const
 {
   std::unique_lock<std::recursive_mutex> lock(mutex_);

--- a/src/menu_handler.cpp
+++ b/src/menu_handler.cpp
@@ -64,7 +64,6 @@ MenuHandler::MenuHandler()
 {
 }
 
-
 MenuHandler::EntryHandle MenuHandler::insert(
   const std::string & title,
   const FeedbackCallback & feedback_cb)
@@ -74,7 +73,6 @@ MenuHandler::EntryHandle MenuHandler::insert(
   top_level_handles_.push_back(handle);
   return handle;
 }
-
 
 MenuHandler::EntryHandle MenuHandler::insert(
   const std::string & title,

--- a/src/menu_handler.cpp
+++ b/src/menu_handler.cpp
@@ -28,14 +28,17 @@
 
 // Author: David Gossow
 
+#include <exception>
 #include <functional>
-#include <memory>
 #include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "interactive_markers/menu_handler.hpp"
+
+#include "visualization_msgs/msg/interactive_marker.hpp"
+#include "visualization_msgs/msg/menu_entry.hpp"
 
 // TODO(jacobperron): Remove this macro when it is available upstream
 // See: https://github.com/ros2/rcutils/pull/112

--- a/src/menu_handler.cpp
+++ b/src/menu_handler.cpp
@@ -64,6 +64,7 @@ MenuHandler::MenuHandler()
 {
 }
 
+
 MenuHandler::EntryHandle MenuHandler::insert(
   const std::string & title,
   const FeedbackCallback & feedback_cb)
@@ -73,6 +74,7 @@ MenuHandler::EntryHandle MenuHandler::insert(
   top_level_handles_.push_back(handle);
   return handle;
 }
+
 
 MenuHandler::EntryHandle MenuHandler::insert(
   const std::string & title,

--- a/src/message_context.cpp
+++ b/src/message_context.cpp
@@ -111,7 +111,7 @@ bool MessageContext<MsgT>::getTransform(
         header.frame_id = target_frame_;
       }
     }
-  } catch (tf2::ExtrapolationException &) {
+  } catch (const tf2::ExtrapolationException &) {
     // Get latest common time
     // Call lookupTransform with time=0 and use the stamp on the resultant transform.
     geometry_msgs::msg::TransformStamped transform =
@@ -127,7 +127,7 @@ bool MessageContext<MsgT>::getTransform(
       throw exceptions::TransformError(oss.str());
     }
     return false;
-  } catch (tf2::TransformException & e) {
+  } catch (const tf2::TransformException & e) {
     throw exceptions::TransformError(e.what());
   }
   return true;

--- a/src/message_context.cpp
+++ b/src/message_context.cpp
@@ -201,10 +201,10 @@ void MessageContext<visualization_msgs::msg::InteractiveMarkerUpdate>::init()
   for (size_t i = 0; i < msg->poses.size(); i++) {
     open_pose_idx_.push_back(i);
   }
-  for (unsigned i = 0; i < msg->markers.size(); i++) {
+  for (size_t i = 0; i < msg->markers.size(); i++) {
     autoComplete(msg->markers[i], enable_autocomplete_transparency_);
   }
-  for (unsigned i = 0; i < msg->poses.size(); i++) {
+  for (size_t i = 0; i < msg->poses.size(); i++) {
     // correct empty orientation
     if (msg->poses[i].pose.orientation.w == 0 && msg->poses[i].pose.orientation.x == 0 &&
       msg->poses[i].pose.orientation.y == 0 && msg->poses[i].pose.orientation.z == 0)
@@ -221,7 +221,7 @@ void MessageContext<visualization_msgs::srv::GetInteractiveMarkers::Response>::i
   for (size_t i = 0; i < msg->markers.size(); i++) {
     open_marker_idx_.push_back(i);
   }
-  for (unsigned i = 0; i < msg->markers.size(); i++) {
+  for (size_t i = 0; i < msg->markers.size(); i++) {
     autoComplete(msg->markers[i], enable_autocomplete_transparency_);
   }
 }

--- a/src/message_context.cpp
+++ b/src/message_context.cpp
@@ -32,13 +32,24 @@
 
 #include <list>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
+#include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
 #include "rcutils/logging_macros.h"
 #include "tf2/buffer_core_interface.h"
+#include "tf2/time.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "rclcpp/time.hpp"
+#include "std_msgs/msg/header.hpp"
+#include "visualization_msgs/msg/interactive_marker.hpp"
+#include "visualization_msgs/msg/interactive_marker_control.hpp"
+#include "visualization_msgs/msg/interactive_marker_pose.hpp"
+#include "visualization_msgs/msg/interactive_marker_update.hpp"
+#include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/srv/get_interactive_markers.hpp"
 
 #include "interactive_markers/exceptions.hpp"

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -374,7 +374,7 @@ void makeDisc(
 void makeViewFacingButton(
   const visualization_msgs::msg::InteractiveMarker & msg,
   visualization_msgs::msg::InteractiveMarkerControl & control,
-  std::string text)
+  const std::string & text)
 {
   control.orientation_mode = visualization_msgs::msg::InteractiveMarkerControl::VIEW_FACING;
   control.independent_marker_orientation = false;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -39,8 +39,16 @@
 #include <string>
 #include <vector>
 
+#include "geometry_msgs/msg/point.hpp"
+#include "geometry_msgs/msg/vector3.hpp"
+#include "std_msgs/msg/color_rgba.hpp"
+#include "visualization_msgs/msg/interactive_marker.hpp"
+#include "visualization_msgs/msg/interactive_marker_control.hpp"
+#include "visualization_msgs/msg/marker.hpp"
+
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2/LinearMath/Matrix3x3.h"
+#include "tf2/LinearMath/Vector3.h"
 
 #include "interactive_markers/tools.hpp"
 

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -86,7 +86,7 @@ void autoComplete(
   msg.pose.orientation.w = int_marker_orientation.w();
 
   // complete the controls
-  for (unsigned c = 0; c < msg.controls.size(); c++) {
+  for (size_t c = 0; c < msg.controls.size(); c++) {
     autoComplete(msg, msg.controls[c], enable_autocomplete_transparency);
   }
 
@@ -97,7 +97,7 @@ void uniqueifyControlNames(visualization_msgs::msg::InteractiveMarker & msg)
 {
   int uniqueification_number = 0;
   std::set<std::string> names;
-  for (unsigned c = 0; c < msg.controls.size(); c++) {
+  for (size_t c = 0; c < msg.controls.size(); c++) {
     std::string name = msg.controls[c].name;
     while (names.find(name) != names.end()) {
       std::stringstream ss;
@@ -157,7 +157,7 @@ void autoComplete(
   tf2::Vector3 int_marker_position(msg.pose.position.x, msg.pose.position.y, msg.pose.position.z);
 
   // fill in missing pose information into the markers
-  for (unsigned m = 0; m < control.markers.size(); m++) {
+  for (size_t m = 0; m < control.markers.size(); m++) {
     visualization_msgs::msg::Marker & marker = control.markers[m];
 
     if (marker.scale.x == 0) {

--- a/test/interactive_markers/interactive_marker_fixtures.cpp
+++ b/test/interactive_markers/interactive_marker_fixtures.cpp
@@ -26,16 +26,43 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef INTERACTIVE_MARKERS__INTERACTIVE_MARKER_FIXTURES_HPP_
-#define INTERACTIVE_MARKERS__INTERACTIVE_MARKER_FIXTURES_HPP_
-
 #include <vector>
 
 #include "visualization_msgs/msg/interactive_marker.hpp"
+#include "visualization_msgs/msg/interactive_marker_control.hpp"
+#include "visualization_msgs/msg/menu_entry.hpp"
 
-#include "interactive_markers/visibility_control.hpp"
+#include "interactive_marker_fixtures.hpp"
 
-INTERACTIVE_MARKERS_PUBLIC
-std::vector<visualization_msgs::msg::InteractiveMarker> get_interactive_markers();
-
-#endif  // INTERACTIVE_MARKERS__INTERACTIVE_MARKER_FIXTURES_HPP_
+std::vector<visualization_msgs::msg::InteractiveMarker> get_interactive_markers()
+{
+  std::vector<visualization_msgs::msg::InteractiveMarker> markers;
+  {
+    visualization_msgs::msg::InteractiveMarker marker;
+    marker.name = "test_marker_0";
+    marker.header.frame_id = "test_frame_id";
+    markers.push_back(marker);
+  }
+  {
+    visualization_msgs::msg::InteractiveMarker marker;
+    marker.name = "test_marker_1";
+    marker.header.frame_id = "test_frame_id";
+    marker.pose.position.x = 1.0;
+    marker.pose.orientation.w = 1.0;
+    marker.description = "My test marker description";
+    marker.scale = 3.14f;
+    visualization_msgs::msg::MenuEntry menu_entry;
+    menu_entry.id = 42;
+    menu_entry.title = "My test menu title";
+    menu_entry.command = "Some test command to be run";
+    marker.menu_entries.push_back(menu_entry);
+    visualization_msgs::msg::InteractiveMarkerControl control;
+    control.name = "test_control_name";
+    control.orientation.w = 1.0;
+    control.always_visible = true;
+    control.description = "My test control description";
+    marker.controls.push_back(control);
+    markers.push_back(marker);
+  }
+  return markers;
+}

--- a/test/interactive_markers/interactive_marker_fixtures.cpp
+++ b/test/interactive_markers/interactive_marker_fixtures.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Open Source Robotics Foundation, Inc.
+// Copyright (c) 2023, Open Source Robotics Foundation, Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:

--- a/test/interactive_markers/interactive_marker_fixtures.hpp
+++ b/test/interactive_markers/interactive_marker_fixtures.hpp
@@ -33,9 +33,6 @@
 
 #include "visualization_msgs/msg/interactive_marker.hpp"
 
-#include "interactive_markers/visibility_control.hpp"
-
-INTERACTIVE_MARKERS_PUBLIC
 std::vector<visualization_msgs::msg::InteractiveMarker> get_interactive_markers();
 
 #endif  // INTERACTIVE_MARKERS__INTERACTIVE_MARKER_FIXTURES_HPP_

--- a/test/interactive_markers/mock_interactive_marker_client.hpp
+++ b/test/interactive_markers/mock_interactive_marker_client.hpp
@@ -28,14 +28,13 @@
 
 #ifndef INTERACTIVE_MARKERS__MOCK_INTERACTIVE_MARKER_CLIENT_HPP_
 #define INTERACTIVE_MARKERS__MOCK_INTERACTIVE_MARKER_CLIENT_HPP_
+
+#include <chrono>
 #include <memory>
 #include <string>
 
-#include "geometry_msgs/msg/pose.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "visualization_msgs/msg/interactive_marker.hpp"
 #include "visualization_msgs/msg/interactive_marker_feedback.hpp"
-#include "visualization_msgs/msg/interactive_marker_pose.hpp"
 #include "visualization_msgs/msg/interactive_marker_update.hpp"
 #include "visualization_msgs/srv/get_interactive_markers.hpp"
 

--- a/test/interactive_markers/mock_interactive_marker_server.hpp
+++ b/test/interactive_markers/mock_interactive_marker_server.hpp
@@ -28,6 +28,7 @@
 
 #ifndef INTERACTIVE_MARKERS__MOCK_INTERACTIVE_MARKER_SERVER_HPP_
 #define INTERACTIVE_MARKERS__MOCK_INTERACTIVE_MARKER_SERVER_HPP_
+
 #include <memory>
 #include <string>
 #include <vector>

--- a/test/interactive_markers/test_interactive_marker_client.cpp
+++ b/test/interactive_markers/test_interactive_marker_client.cpp
@@ -29,12 +29,19 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
+#include "builtin_interfaces/msg/time.hpp"
+#include "geometry_msgs/msg/pose.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/buffer_core.h"
+#include "visualization_msgs/msg/interactive_marker.hpp"
+#include "visualization_msgs/msg/interactive_marker_update.hpp"
+#include "visualization_msgs/srv/get_interactive_markers.hpp"
 
 #include "interactive_marker_fixtures.hpp"
 #include "mock_interactive_marker_server.hpp"

--- a/test/interactive_markers/test_interactive_marker_server.cpp
+++ b/test/interactive_markers/test_interactive_marker_server.cpp
@@ -34,6 +34,13 @@
 #include <thread>
 #include <vector>
 
+#include "geometry_msgs/msg/pose.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/header.hpp"
+#include "visualization_msgs/msg/interactive_marker.hpp"
+#include "visualization_msgs/msg/interactive_marker_feedback.hpp"
+#include "visualization_msgs/srv/get_interactive_markers.hpp"
+
 #include "interactive_marker_fixtures.hpp"
 #include "mock_interactive_marker_client.hpp"
 #include "timed_expect.hpp"


### PR DESCRIPTION
This PR does a pretty comprehensive cleanup of the package.  Things that are done:

1.  Switch to using `tf2_geometry_msgs::tf2_geometry_msgs` target as appropriate.  This avoids a hard-coded path on Windows.
2.  Make sure to add in *all* dependencies of this package.
3.  Make sure to include-what-you-use in all files.
4.  Switch the APIs to a constref std::string where we can.  This is more efficient.  This will be an ABI break, but should not be an API break.
5.  Get rid of unnecessary `using` statements.
6.  Use constref for exceptions types (it is minorly more efficient).
7.  Use `size_t` for iteration over container types.
8.  Switch one of the test files to be a library so that it could be included in more than one place.