### PR TITLE
Fixed C++20 warning that ‘++’ expression of ‘volatile’-qualified type is deprecated

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -190,7 +190,7 @@ void autoComplete(
     marker.pose.orientation.z = marker_orientation.z();
     marker.pose.orientation.w = marker_orientation.w();
 
-    static volatile unsigned id = 0;
+    static unsigned id = 0;
     marker.id = id++;
     marker.ns = msg.name;
 


### PR DESCRIPTION
I'm not sure what the intention here with this specific volatile use is, but I assume it was to account for a multithreaded environment?

If so, I replace the volatile with std::atomic which is better suited in this PR. Otherwise, I can just remove the volatile qualifier.