### PR TITLE
Fixed Deadlock

### DIFF
--- a/include/interactive_markers/interactive_marker_client.h
+++ b/include/interactive_markers/interactive_marker_client.h
@@ -34,6 +34,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/recursive_mutex.hpp>
 #include <boost/function.hpp>
 #include <boost/unordered_map.hpp>
 
@@ -163,7 +164,7 @@ private:
   typedef boost::shared_ptr<SingleClient> SingleClientPtr;
   typedef boost::unordered_map<std::string, SingleClientPtr> M_SingleClient;
   M_SingleClient publisher_contexts_;
-  boost::mutex publisher_contexts_mutex_;
+  boost::recursive_mutex publisher_contexts_mutex_;
 
   tf2_ros::Buffer& tf_;
   std::string target_frame_;

--- a/src/interactive_marker_client.cpp
+++ b/src/interactive_marker_client.cpp
@@ -122,7 +122,7 @@ void InteractiveMarkerClient::shutdown()
   case RUNNING:
     init_sub_.shutdown();
     update_sub_.shutdown();
-    boost::lock_guard<boost::mutex> lock(publisher_contexts_mutex_);
+    boost::lock_guard<boost::recursive_mutex> lock(publisher_contexts_mutex_);
     publisher_contexts_.clear();
     last_num_publishers_=0;
     state_=IDLE;
@@ -179,7 +179,7 @@ void InteractiveMarkerClient::process( const MsgConstPtrT& msg )
 
   SingleClientPtr client;
   {
-    boost::lock_guard<boost::mutex> lock(publisher_contexts_mutex_);
+    boost::lock_guard<boost::recursive_mutex> lock(publisher_contexts_mutex_);
 
     M_SingleClient::iterator context_it = publisher_contexts_.find(msg->server_id);
 
@@ -238,7 +238,7 @@ void InteractiveMarkerClient::update()
 
     // check if all single clients are finished with the init channels
     bool initialized = true;
-    boost::lock_guard<boost::mutex> lock(publisher_contexts_mutex_);
+    boost::lock_guard<boost::recursive_mutex> lock(publisher_contexts_mutex_);
     M_SingleClient::iterator it;
     for ( it = publisher_contexts_.begin(); it!=publisher_contexts_.end(); ++it )
     {


### PR DESCRIPTION
This fixes a deadlock when publishing an visualization_msgs::InteractiveMarker message where the controls list is empty, see http://docs.ros.org/en/api/visualization_msgs/html/msg/InteractiveMarker.html

If you run the program in a debugger, you can see that the same mutex is locked in update() and shutdown(), which are both on the call stack and which leads to the deadlock.
