### PR TITLE
Revert "Replace deprecated `spin_until_future_complete` with `spin_un…

### DIFF
--- a/test/interactive_markers/test_interactive_marker_server.cpp
+++ b/test/interactive_markers/test_interactive_marker_server.cpp
@@ -371,7 +371,7 @@ TEST_F(TestInteractiveMarkerServerWithMarkers, get_interactive_markers_communica
   using namespace std::chrono_literals;
 
   auto future = mock_client_->requestInteractiveMarkers();
-  auto ret = executor_.spin_until_complete(future, 3000ms);
+  auto ret = executor_.spin_until_future_complete(future, 3000ms);
   ASSERT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
   visualization_msgs::srv::GetInteractiveMarkers::Response::SharedPtr response = future.get();
   ASSERT_EQ(response->markers.size(), markers_.size());


### PR DESCRIPTION
This reverts commit 71212efc21f2028e2c214a4a662aea98fda47804.

As stated in https://github.com/ros-visualization/interactive_markers/pull/90#issuecomment-1781236247